### PR TITLE
Don't check whether constructor args are const in statementize pass

### DIFF
--- a/deps/poulet4/lib/Ccomp/CCompSel.v
+++ b/deps/poulet4/lib/Ccomp/CCompSel.v
@@ -1604,13 +1604,7 @@ End CCompSel.
 
 Definition helloworld_program_sel := Statementize.TranslateProgram helloworld_program.
 Definition test_program_only := 
-  match helloworld_program_sel with 
-  | inl helloworld_program_sel => CCompSel.Compile nat helloworld_program_sel
-  | inr _ => Errors.Error (Errors.msg "statementize failed")
-  end.
+  CCompSel.Compile nat helloworld_program_sel.
 
 Definition test := 
-  match helloworld_program_sel with 
-  | inl helloworld_program_sel => CCompSel.Compile_print nat helloworld_program_sel
-  | inr _ => tt
-  end.
+  CCompSel.Compile_print nat helloworld_program_sel.


### PR DESCRIPTION
I could be wrong here but I think the statementize pass doesn't need to verify that constructor arguments are const. If it's being fed garbage (a program with non-const constructor arguments) it's okay for it to produce garbage (a program with side effects in a constructor argument list).

It should be a typechecker invariant that we can enforce separately.