### PR TITLE
Properly Merge Switch Statements

### DIFF
--- a/deps/poulet4/lib/LightExamples/MultiProtocol.v
+++ b/deps/poulet4/lib/LightExamples/MultiProtocol.v
@@ -20,20 +20,20 @@ Definition packet_in := DeclExternObject NoInfo
           [(MkParameter false In (TypBit 32%N) None
                 {| stags := NoInfo; str := "sizeInBits" |})]);
      (ProtoMethod NoInfo
-          (TypTypeName (BareName {| stags := NoInfo; str := "T1" |}))
+          (TypTypeName {| stags := NoInfo; str := "T1" |})
           {| stags := NoInfo; str := "lookahead" |}
           [{| stags := NoInfo; str := "T1" |}] nil);
      (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "extract" |}
           [{| stags := NoInfo; str := "T0" |}]
           [(MkParameter false Out
-                (TypTypeName (BareName {| stags := NoInfo; str := "T0" |}))
+                (TypTypeName {| stags := NoInfo; str := "T0" |})
                 None {| stags := NoInfo; str := "variableSizeHeader" |});
            (MkParameter false In (TypBit 32%N) None
                 {| stags := NoInfo; str := "variableFieldSizeInBits" |})]);
      (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "extract" |}
           [{| stags := NoInfo; str := "T" |}]
           [(MkParameter false Out
-                (TypTypeName (BareName {| stags := NoInfo; str := "T" |}))
+                (TypTypeName {| stags := NoInfo; str := "T" |})
                 None {| stags := NoInfo; str := "hdr" |})])].
 
 Definition packet_out := DeclExternObject NoInfo
@@ -41,7 +41,7 @@ Definition packet_out := DeclExternObject NoInfo
     [(ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "emit" |}
           [{| stags := NoInfo; str := "T2" |}]
           [(MkParameter false In
-                (TypTypeName (BareName {| stags := NoInfo; str := "T2" |}))
+                (TypTypeName {| stags := NoInfo; str := "T2" |})
                 None {| stags := NoInfo; str := "hdr" |})])].
 
 Definition verify'check'toSignal := DeclExternFunction NoInfo TypVoid
@@ -117,7 +117,7 @@ Definition counter := DeclExternObject NoInfo
                 {| stags := NoInfo; str := "size" |});
            (MkParameter false Directionless
                 (TypTypeName
-                 (BareName {| stags := NoInfo; str := "CounterType" |})) 
+                 {| stags := NoInfo; str := "CounterType" |})
                 None {| stags := NoInfo; str := "type" |})]);
      (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "count" |} nil
           [(MkParameter false In (TypBit 32%N) None
@@ -128,7 +128,7 @@ Definition direct_counter := DeclExternObject NoInfo
     [(ProtoConstructor NoInfo {| stags := NoInfo; str := "direct_counter" |}
           [(MkParameter false Directionless
                 (TypTypeName
-                 (BareName {| stags := NoInfo; str := "CounterType" |})) 
+                 {| stags := NoInfo; str := "CounterType" |})
                 None {| stags := NoInfo; str := "type" |})]);
      (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "count" |} nil
           nil)].
@@ -140,7 +140,7 @@ Definition meter := DeclExternObject NoInfo
                 {| stags := NoInfo; str := "size" |});
            (MkParameter false Directionless
                 (TypTypeName
-                 (BareName {| stags := NoInfo; str := "MeterType" |})) 
+                 {| stags := NoInfo; str := "MeterType" |})
                 None {| stags := NoInfo; str := "type" |})]);
      (ProtoMethod NoInfo TypVoid
           {| stags := NoInfo; str := "execute_meter" |}
@@ -148,7 +148,7 @@ Definition meter := DeclExternObject NoInfo
           [(MkParameter false In (TypBit 32%N) None
                 {| stags := NoInfo; str := "index" |});
            (MkParameter false Out
-                (TypTypeName (BareName {| stags := NoInfo; str := "T3" |}))
+                (TypTypeName {| stags := NoInfo; str := "T3" |})
                 None {| stags := NoInfo; str := "result" |})])].
 
 Definition direct_meter := DeclExternObject NoInfo
@@ -157,11 +157,11 @@ Definition direct_meter := DeclExternObject NoInfo
     [(ProtoConstructor NoInfo {| stags := NoInfo; str := "direct_meter" |}
           [(MkParameter false Directionless
                 (TypTypeName
-                 (BareName {| stags := NoInfo; str := "MeterType" |})) 
+                   {| stags := NoInfo; str := "MeterType" |})
                 None {| stags := NoInfo; str := "type" |})]);
      (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "read" |} nil
           [(MkParameter false Out
-                (TypTypeName (BareName {| stags := NoInfo; str := "T4" |}))
+                (TypTypeName {| stags := NoInfo; str := "T4" |})
                 None {| stags := NoInfo; str := "result" |})])].
 
 Definition register := DeclExternObject NoInfo
@@ -174,11 +174,11 @@ Definition register := DeclExternObject NoInfo
           [(MkParameter false In (TypBit 32%N) None
                 {| stags := NoInfo; str := "index" |});
            (MkParameter false In
-                (TypTypeName (BareName {| stags := NoInfo; str := "T5" |}))
+                (TypTypeName {| stags := NoInfo; str := "T5" |})
                 None {| stags := NoInfo; str := "value" |})]);
      (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "read" |} nil
           [(MkParameter false Out
-                (TypTypeName (BareName {| stags := NoInfo; str := "T5" |}))
+                (TypTypeName {| stags := NoInfo; str := "T5" |})
                 None {| stags := NoInfo; str := "result" |});
            (MkParameter false In (TypBit 32%N) None
                 {| stags := NoInfo; str := "index" |})])].
@@ -193,13 +193,13 @@ Definition random'result'lo'hi := DeclExternFunction NoInfo TypVoid
     {| stags := NoInfo; str := "random" |}
     [{| stags := NoInfo; str := "T6" |}]
     [(MkParameter false Out
-          (TypTypeName (BareName {| stags := NoInfo; str := "T6" |})) 
+          (TypTypeName {| stags := NoInfo; str := "T6" |})
           None {| stags := NoInfo; str := "result" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T6" |})) 
+          (TypTypeName {| stags := NoInfo; str := "T6" |})
           None {| stags := NoInfo; str := "lo" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T6" |})) 
+          (TypTypeName  {| stags := NoInfo; str := "T6" |})
           None {| stags := NoInfo; str := "hi" |})].
 
 Definition digest'receiver'data := DeclExternFunction NoInfo TypVoid
@@ -208,7 +208,7 @@ Definition digest'receiver'data := DeclExternFunction NoInfo TypVoid
     [(MkParameter false In (TypBit 32%N) None
           {| stags := NoInfo; str := "receiver" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T7" |})) 
+          (TypTypeName {| stags := NoInfo; str := "T7" |})
           None {| stags := NoInfo; str := "data" |})].
 
 Definition HashAlgorithm := DeclEnum NoInfo
@@ -229,7 +229,7 @@ Definition mark_to_drop'standard_metadata := DeclExternFunction NoInfo
     TypVoid {| stags := NoInfo; str := "mark_to_drop" |} nil
     [(MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+             {| stags := NoInfo; str := "standard_metadata_t" |})
           None {| stags := NoInfo; str := "standard_metadata" |})].
 
 Definition hash'result'algo'base'data'max := DeclExternFunction NoInfo
@@ -237,20 +237,20 @@ Definition hash'result'algo'base'data'max := DeclExternFunction NoInfo
     [{| stags := NoInfo; str := "O" |}; {| stags := NoInfo; str := "T8" |};
      {| stags := NoInfo; str := "D" |}; {| stags := NoInfo; str := "M" |}]
     [(MkParameter false Out
-          (TypTypeName (BareName {| stags := NoInfo; str := "O" |})) 
+          (TypTypeName {| stags := NoInfo; str := "O" |})
           None {| stags := NoInfo; str := "result" |});
      (MkParameter false In
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+             {| stags := NoInfo; str := "HashAlgorithm" |})
           None {| stags := NoInfo; str := "algo" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T8" |})) 
+          (TypTypeName {| stags := NoInfo; str := "T8" |})
           None {| stags := NoInfo; str := "base" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "D" |})) 
+          (TypTypeName {| stags := NoInfo; str := "D" |})
           None {| stags := NoInfo; str := "data" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "M" |})) 
+          (TypTypeName {| stags := NoInfo; str := "M" |})
           None {| stags := NoInfo; str := "max" |})].
 
 Definition action_selector := DeclExternObject NoInfo
@@ -258,7 +258,7 @@ Definition action_selector := DeclExternObject NoInfo
     [(ProtoConstructor NoInfo {| stags := NoInfo; str := "action_selector" |}
           [(MkParameter false Directionless
                 (TypTypeName
-                 (BareName {| stags := NoInfo; str := "HashAlgorithm" |}))
+                   {| stags := NoInfo; str := "HashAlgorithm" |})
                 None {| stags := NoInfo; str := "algorithm" |});
            (MkParameter false Directionless (TypBit 32%N) None
                 {| stags := NoInfo; str := "size" |});
@@ -276,7 +276,7 @@ Definition Checksum16 := DeclExternObject NoInfo
      (ProtoMethod NoInfo (TypBit 16%N) {| stags := NoInfo; str := "get" |}
           [{| stags := NoInfo; str := "D9" |}]
           [(MkParameter false In
-                (TypTypeName (BareName {| stags := NoInfo; str := "D9" |}))
+                (TypTypeName {| stags := NoInfo; str := "D9" |})
                 None {| stags := NoInfo; str := "data" |})])].
 
 Definition verify_checksum'condition'data'checksum'algo := DeclExternFunction
@@ -286,14 +286,14 @@ Definition verify_checksum'condition'data'checksum'algo := DeclExternFunction
     [(MkParameter false In TypBool None
           {| stags := NoInfo; str := "condition" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T10" |})) 
+          (TypTypeName {| stags := NoInfo; str := "T10" |})
           None {| stags := NoInfo; str := "data" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "O11" |})) 
+          (TypTypeName {| stags := NoInfo; str := "O11" |})
           None {| stags := NoInfo; str := "checksum" |});
      (MkParameter false Directionless
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+             {| stags := NoInfo; str := "HashAlgorithm" |})
           None {| stags := NoInfo; str := "algo" |})].
 
 Definition update_checksum'condition'data'checksum'algo := DeclExternFunction
@@ -303,14 +303,14 @@ Definition update_checksum'condition'data'checksum'algo := DeclExternFunction
     [(MkParameter false In TypBool None
           {| stags := NoInfo; str := "condition" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T12" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T12" |}))
           None {| stags := NoInfo; str := "data" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "O13" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "O13" |}))
           None {| stags := NoInfo; str := "checksum" |});
      (MkParameter false Directionless
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+           ({| stags := NoInfo; str := "HashAlgorithm" |}))
           None {| stags := NoInfo; str := "algo" |})].
 
 Definition verify_checksum_with_payload'condition'data'checksum'algo := DeclExternFunction
@@ -321,14 +321,14 @@ Definition verify_checksum_with_payload'condition'data'checksum'algo := DeclExte
     [(MkParameter false In TypBool None
           {| stags := NoInfo; str := "condition" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T14" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T14" |}))
           None {| stags := NoInfo; str := "data" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "O15" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "O15" |}))
           None {| stags := NoInfo; str := "checksum" |});
      (MkParameter false Directionless
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+           ({| stags := NoInfo; str := "HashAlgorithm" |}))
           None {| stags := NoInfo; str := "algo" |})].
 
 Definition update_checksum_with_payload'condition'data'checksum'algo := DeclExternFunction
@@ -339,34 +339,34 @@ Definition update_checksum_with_payload'condition'data'checksum'algo := DeclExte
     [(MkParameter false In TypBool None
           {| stags := NoInfo; str := "condition" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T16" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T16" |}))
           None {| stags := NoInfo; str := "data" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "O17" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "O17" |}))
           None {| stags := NoInfo; str := "checksum" |});
      (MkParameter false Directionless
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+           ({| stags := NoInfo; str := "HashAlgorithm" |}))
           None {| stags := NoInfo; str := "algo" |})].
 
 Definition resubmit'data := DeclExternFunction NoInfo TypVoid
     {| stags := NoInfo; str := "resubmit" |}
     [{| stags := NoInfo; str := "T18" |}]
     [(MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T18" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T18" |}))
           None {| stags := NoInfo; str := "data" |})].
 
 Definition recirculate'data := DeclExternFunction NoInfo TypVoid
     {| stags := NoInfo; str := "recirculate" |}
     [{| stags := NoInfo; str := "T19" |}]
     [(MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T19" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T19" |}))
           None {| stags := NoInfo; str := "data" |})].
 
 Definition clone'type'session := DeclExternFunction NoInfo TypVoid
     {| stags := NoInfo; str := "clone" |} nil
     [(MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "CloneType" |}))
+          (TypTypeName ({| stags := NoInfo; str := "CloneType" |}))
           None {| stags := NoInfo; str := "type" |});
      (MkParameter false In (TypBit 32%N) None
           {| stags := NoInfo; str := "session" |})].
@@ -375,12 +375,12 @@ Definition clone3'type'session'data := DeclExternFunction NoInfo TypVoid
     {| stags := NoInfo; str := "clone3" |}
     [{| stags := NoInfo; str := "T20" |}]
     [(MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "CloneType" |}))
+          (TypTypeName ({| stags := NoInfo; str := "CloneType" |}))
           None {| stags := NoInfo; str := "type" |});
      (MkParameter false In (TypBit 32%N) None
           {| stags := NoInfo; str := "session" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T20" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T20" |}))
           None {| stags := NoInfo; str := "data" |})].
 
 Definition truncate'length := DeclExternFunction NoInfo TypVoid
@@ -409,24 +409,24 @@ Definition log_msg'msg'data := DeclExternFunction NoInfo TypVoid
     [(MkParameter false Directionless TypString None
           {| stags := NoInfo; str := "msg" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "T21" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "T21" |}))
           None {| stags := NoInfo; str := "data" |})].
 
 Definition Parser := DeclParserType NoInfo
     {| stags := NoInfo; str := "Parser" |}
     [{| stags := NoInfo; str := "H" |}; {| stags := NoInfo; str := "M22" |}]
     [(MkParameter false Directionless
-          (TypTypeName (BareName {| stags := NoInfo; str := "packet_in" |}))
+          (TypTypeName ({| stags := NoInfo; str := "packet_in" |}))
           None {| stags := NoInfo; str := "b" |});
      (MkParameter false Out
-          (TypTypeName (BareName {| stags := NoInfo; str := "H" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "H" |}))
           None {| stags := NoInfo; str := "parsedHdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "M22" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "M22" |}))
           None {| stags := NoInfo; str := "meta" |});
      (MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+           ({| stags := NoInfo; str := "standard_metadata_t" |}))
           None {| stags := NoInfo; str := "standard_metadata" |})].
 
 Definition VerifyChecksum := DeclControlType NoInfo
@@ -434,10 +434,10 @@ Definition VerifyChecksum := DeclControlType NoInfo
     [{| stags := NoInfo; str := "H23" |};
      {| stags := NoInfo; str := "M24" |}]
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "H23" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "H23" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "M24" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "M24" |}))
           None {| stags := NoInfo; str := "meta" |})].
 
 Definition Ingress := DeclControlType NoInfo
@@ -445,14 +445,14 @@ Definition Ingress := DeclControlType NoInfo
     [{| stags := NoInfo; str := "H25" |};
      {| stags := NoInfo; str := "M26" |}]
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "H25" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "H25" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "M26" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "M26" |}))
           None {| stags := NoInfo; str := "meta" |});
      (MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+           ({| stags := NoInfo; str := "standard_metadata_t" |}))
           None {| stags := NoInfo; str := "standard_metadata" |})].
 
 Definition Egress := DeclControlType NoInfo
@@ -460,14 +460,14 @@ Definition Egress := DeclControlType NoInfo
     [{| stags := NoInfo; str := "H27" |};
      {| stags := NoInfo; str := "M28" |}]
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "H27" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "H27" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "M28" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "M28" |}))
           None {| stags := NoInfo; str := "meta" |});
      (MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+           ({| stags := NoInfo; str := "standard_metadata_t" |}))
           None {| stags := NoInfo; str := "standard_metadata" |})].
 
 Definition ComputeChecksum := DeclControlType NoInfo
@@ -475,20 +475,20 @@ Definition ComputeChecksum := DeclControlType NoInfo
     [{| stags := NoInfo; str := "H29" |};
      {| stags := NoInfo; str := "M30" |}]
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "H29" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "H29" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "M30" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "M30" |}))
           None {| stags := NoInfo; str := "meta" |})].
 
 Definition Deparser := DeclControlType NoInfo
     {| stags := NoInfo; str := "Deparser" |}
     [{| stags := NoInfo; str := "H31" |}]
     [(MkParameter false Directionless
-          (TypTypeName (BareName {| stags := NoInfo; str := "packet_out" |}))
+          (TypTypeName ({| stags := NoInfo; str := "packet_out" |}))
           None {| stags := NoInfo; str := "b" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "H31" |})) 
+          (TypTypeName ({| stags := NoInfo; str := "H31" |}))
           None {| stags := NoInfo; str := "hdr" |})].
 
 Definition V1Switch := DeclPackageType NoInfo
@@ -498,43 +498,43 @@ Definition V1Switch := DeclPackageType NoInfo
     [(MkParameter false Directionless
           (TypSpecializedType
                (TypTypeName
-                (BareName {| stags := NoInfo; str := "Parser" |}))
-               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
-                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+                ({| stags := NoInfo; str := "Parser" |}))
+               [(TypTypeName ({| stags := NoInfo; str := "H32" |}));
+                (TypTypeName ({| stags := NoInfo; str := "M33" |}))])
           None {| stags := NoInfo; str := "p" |});
      (MkParameter false Directionless
           (TypSpecializedType
                (TypTypeName
-                (BareName {| stags := NoInfo; str := "VerifyChecksum" |}))
-               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
-                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+                ({| stags := NoInfo; str := "VerifyChecksum" |}))
+               [(TypTypeName ({| stags := NoInfo; str := "H32" |}));
+                (TypTypeName ({| stags := NoInfo; str := "M33" |}))])
           None {| stags := NoInfo; str := "vr" |});
      (MkParameter false Directionless
           (TypSpecializedType
                (TypTypeName
-                (BareName {| stags := NoInfo; str := "Ingress" |}))
-               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
-                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+                ({| stags := NoInfo; str := "Ingress" |}))
+               [(TypTypeName ({| stags := NoInfo; str := "H32" |}));
+                (TypTypeName ({| stags := NoInfo; str := "M33" |}))])
           None {| stags := NoInfo; str := "ig" |});
      (MkParameter false Directionless
           (TypSpecializedType
                (TypTypeName
-                (BareName {| stags := NoInfo; str := "Egress" |}))
-               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
-                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+                ({| stags := NoInfo; str := "Egress" |}))
+               [(TypTypeName ({| stags := NoInfo; str := "H32" |}));
+                (TypTypeName ({| stags := NoInfo; str := "M33" |}))])
           None {| stags := NoInfo; str := "eg" |});
      (MkParameter false Directionless
           (TypSpecializedType
                (TypTypeName
-                (BareName {| stags := NoInfo; str := "ComputeChecksum" |}))
-               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
-                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+                ({| stags := NoInfo; str := "ComputeChecksum" |}))
+               [(TypTypeName ({| stags := NoInfo; str := "H32" |}));
+                (TypTypeName ({| stags := NoInfo; str := "M33" |}))])
           None {| stags := NoInfo; str := "ck" |});
      (MkParameter false Directionless
           (TypSpecializedType
                (TypTypeName
-                (BareName {| stags := NoInfo; str := "Deparser" |}))
-               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}))])
+                ({| stags := NoInfo; str := "Deparser" |}))
+               [(TypTypeName ({| stags := NoInfo; str := "H32" |}))])
           None {| stags := NoInfo; str := "dep" |})].
 
 Definition ingress_metadata_t := DeclStruct NoInfo
@@ -727,17 +727,17 @@ Definition headers := DeclStruct NoInfo
 Definition ParserImpl := DeclParser NoInfo
     {| stags := NoInfo; str := "ParserImpl" |} nil
     [(MkParameter false Directionless
-          (TypTypeName (BareName {| stags := NoInfo; str := "packet_in" |}))
+          (TypTypeName ({| stags := NoInfo; str := "packet_in" |}))
           None {| stags := NoInfo; str := "packet" |});
      (MkParameter false Out
-          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          (TypTypeName ({| stags := NoInfo; str := "headers" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          (TypTypeName ({| stags := NoInfo; str := "metadata" |}))
           None {| stags := NoInfo; str := "meta" |});
      (MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+           ({| stags := NoInfo; str := "standard_metadata_t" |}))
           None {| stags := NoInfo; str := "standard_metadata" |})] nil nil
     [(MkParserState NoInfo {| stags := NoInfo; str := "parse_icmp" |}
           [(MkStatement NoInfo
@@ -750,8 +750,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -760,8 +759,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -779,8 +777,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "icmp" |})
                             (TypHeader
@@ -800,8 +797,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -810,8 +806,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -847,8 +842,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "ipv4" |})
                             (TypHeader
@@ -888,8 +882,7 @@ Definition ParserImpl := DeclParser NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) Out)
                                     {| stags := NoInfo; str := "ipv4" |})
                                (TypHeader
@@ -931,8 +924,7 @@ Definition ParserImpl := DeclParser NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) Out)
                                     {| stags := NoInfo; str := "ipv4" |})
                                (TypHeader
@@ -974,8 +966,7 @@ Definition ParserImpl := DeclParser NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) Out)
                                     {| stags := NoInfo; str := "ipv4" |})
                                (TypHeader
@@ -1218,8 +1209,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -1228,8 +1218,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -1259,8 +1248,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "ipv6" |})
                             (TypHeader
@@ -1291,8 +1279,7 @@ Definition ParserImpl := DeclParser NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) Out)
                                     {| stags := NoInfo; str := "ipv6" |})
                                (TypHeader
@@ -1371,8 +1358,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -1381,8 +1367,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -1415,8 +1400,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "tcp" |})
                             (TypHeader
@@ -1452,8 +1436,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -1462,8 +1445,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -1485,8 +1467,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "udp" |})
                             (TypHeader
@@ -1510,8 +1491,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -1520,8 +1500,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -1541,8 +1520,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "vlan_tag" |})
                             (TypHeader
@@ -1565,8 +1543,7 @@ Definition ParserImpl := DeclParser NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) Out)
                                     {| stags := NoInfo; str := "vlan_tag" |})
                                (TypHeader
@@ -1622,8 +1599,7 @@ Definition ParserImpl := DeclParser NoInfo
                                       {| stags := NoInfo; str := "packet" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo;
+                                     ({| stags := NoInfo;
                                          str := "packet_in" |}))
                                     Directionless)
                                {| stags := NoInfo; str := "extract" |})
@@ -1632,8 +1608,7 @@ Definition ParserImpl := DeclParser NoInfo
                                 [{| stags := NoInfo; str := "T" |}]
                                 [(MkParameter false Out
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo; str := "T" |}))
+                                       ({| stags := NoInfo; str := "T" |}))
                                       None
                                       {| stags := NoInfo; str := "hdr" |})]
                                 FunExtern TypVoid)) Directionless)
@@ -1653,8 +1628,7 @@ Definition ParserImpl := DeclParser NoInfo
                                         {| stags := NoInfo; str := "hdr" |})
                                        NoLocator)
                                       (TypTypeName
-                                       (BareName
-                                        {| stags := NoInfo;
+                                       ({| stags := NoInfo;
                                            str := "headers" |})) Out)
                                  {| stags := NoInfo; str := "ethernet" |})
                             (TypHeader
@@ -1675,8 +1649,7 @@ Definition ParserImpl := DeclParser NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) Out)
                                     {| stags := NoInfo; str := "ethernet" |})
                                (TypHeader
@@ -1751,28 +1724,28 @@ Definition ParserImpl := DeclParser NoInfo
 Definition egress := DeclControl NoInfo
     {| stags := NoInfo; str := "egress" |} nil
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          (TypTypeName ({| stags := NoInfo; str := "headers" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          (TypTypeName ({| stags := NoInfo; str := "metadata" |}))
           None {| stags := NoInfo; str := "meta" |});
      (MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+           ({| stags := NoInfo; str := "standard_metadata_t" |}))
           None {| stags := NoInfo; str := "standard_metadata" |})] nil nil
     (BlockEmpty NoInfo).
 
 Definition ingress := DeclControl NoInfo
     {| stags := NoInfo; str := "ingress" |} nil
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          (TypTypeName ({| stags := NoInfo; str := "headers" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          (TypTypeName ({| stags := NoInfo; str := "metadata" |}))
           None {| stags := NoInfo; str := "meta" |});
      (MkParameter false InOut
           (TypTypeName
-           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+           ({| stags := NoInfo; str := "standard_metadata_t" |}))
           None {| stags := NoInfo; str := "standard_metadata" |})] nil
     [(DeclAction NoInfo {| stags := NoInfo; str := "l2_packet" |} nil nil
           (BlockCons
@@ -1789,8 +1762,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -1829,8 +1801,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -1869,8 +1840,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -1909,8 +1879,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -1949,8 +1918,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -1991,8 +1959,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -2032,8 +1999,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -2070,8 +2036,7 @@ Definition ingress := DeclControl NoInfo
                                (MkFunctionType nil
                                     [(MkParameter false InOut
                                           (TypTypeName
-                                           (BareName
-                                            {| stags := NoInfo;
+                                           ({| stags := NoInfo;
                                                str := "standard_metadata_t" |}))
                                           None
                                           {| stags := NoInfo;
@@ -2085,8 +2050,7 @@ Definition ingress := DeclControl NoInfo
                                      str := "standard_metadata" |})
                                  NoLocator)
                                 (TypTypeName
-                                 (BareName
-                                  {| stags := NoInfo;
+                                 ({| stags := NoInfo;
                                      str := "standard_metadata_t" |})) InOut))])
                     StmUnit) (BlockEmpty NoInfo)));
      (DeclAction NoInfo {| stags := NoInfo; str := "send_packet" |} nil nil
@@ -2102,8 +2066,7 @@ Definition ingress := DeclControl NoInfo
                                              str := "standard_metadata" |})
                                          NoLocator)
                                         (TypTypeName
-                                         (BareName
-                                          {| stags := NoInfo;
+                                         ({| stags := NoInfo;
                                              str := "standard_metadata_t" |}))
                                         InOut)
                                    {| stags := NoInfo;
@@ -2120,8 +2083,7 @@ Definition ingress := DeclControl NoInfo
                                                        str := "meta" |})
                                                    NoLocator)
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "metadata" |}))
                                                   InOut)
                                              {| stags := NoInfo;
@@ -2151,8 +2113,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "ethernet" |})
                                (TypHeader
@@ -2197,8 +2158,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "icmp" |})
                                (TypHeader
@@ -2230,8 +2190,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "ipv4" |})
                                (TypHeader
@@ -2288,8 +2247,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "ipv6" |})
                                (TypHeader
@@ -2337,8 +2295,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "ethernet" |})
                                (TypHeader
@@ -2375,8 +2332,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "meta" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "metadata" |})) InOut)
                                     {| stags := NoInfo;
                                        str := "ing_metadata" |})
@@ -2410,8 +2366,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "tcp" |})
                                (TypHeader
@@ -2458,8 +2413,7 @@ Definition ingress := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) InOut)
                                     {| stags := NoInfo; str := "udp" |})
                                (TypHeader
@@ -2506,8 +2460,7 @@ Definition ingress := DeclControl NoInfo
                                             (TypFunction
                                              (MkFunctionType nil nil FunTable
                                                   (TypTypeName
-                                                   (BareName
-                                                    {| stags := NoInfo;
+                                                   ({| stags := NoInfo;
                                                        str := "apply_result_ethertype_match" |}))))
                                             Directionless) nil nil)
                                   (TypStruct
@@ -2567,8 +2520,7 @@ Definition ingress := DeclControl NoInfo
                                               (MkFunctionType nil nil
                                                    FunTable
                                                    (TypTypeName
-                                                    (BareName
-                                                     {| stags := NoInfo;
+                                                    ({| stags := NoInfo;
                                                         str := "apply_result_ipv4_match" |}))))
                                              Directionless) nil nil) StmUnit)
                               (BlockEmpty NoInfo)));
@@ -2599,8 +2551,7 @@ Definition ingress := DeclControl NoInfo
                                               (MkFunctionType nil nil
                                                    FunTable
                                                    (TypTypeName
-                                                    (BareName
-                                                     {| stags := NoInfo;
+                                                    ({| stags := NoInfo;
                                                         str := "apply_result_ipv6_match" |}))))
                                              Directionless) nil nil) StmUnit)
                               (BlockEmpty NoInfo)));
@@ -2626,8 +2577,7 @@ Definition ingress := DeclControl NoInfo
                                               (MkFunctionType nil nil
                                                    FunTable
                                                    (TypTypeName
-                                                    (BareName
-                                                     {| stags := NoInfo;
+                                                    ({| stags := NoInfo;
                                                         str := "apply_result_l2_match" |}))))
                                              Directionless) nil nil) StmUnit)
                               (BlockEmpty NoInfo)))]) StmUnit)
@@ -2647,8 +2597,7 @@ Definition ingress := DeclControl NoInfo
                                                                 str := "hdr" |})
                                                             NoLocator)
                                                            (TypTypeName
-                                                            (BareName
-                                                             {| stags := NoInfo;
+                                                            ({| stags := NoInfo;
                                                                 str := "headers" |}))
                                                            InOut)
                                                       {| stags := NoInfo;
@@ -2714,8 +2663,7 @@ Definition ingress := DeclControl NoInfo
                                                    (MkFunctionType nil nil
                                                         FunTable
                                                         (TypTypeName
-                                                         (BareName
-                                                          {| stags := NoInfo;
+                                                         ({| stags := NoInfo;
                                                              str := "apply_result_tcp_check" |}))))
                                                   Directionless) nil nil)
                                         StmUnit) (BlockEmpty NoInfo)))
@@ -2742,8 +2690,7 @@ Definition ingress := DeclControl NoInfo
                                                                     str := "hdr" |})
                                                                     NoLocator)
                                                                     (TypTypeName
-                                                                    (BareName
-                                                                    {| 
+                                                                    ({|
                                                                     stags := NoInfo;
                                                                     str := "headers" |}))
                                                                     InOut)
@@ -2818,8 +2765,7 @@ Definition ingress := DeclControl NoInfo
                                                                     nil nil
                                                                     FunTable
                                                                     (TypTypeName
-                                                                    (BareName
-                                                                    {| 
+                                                                    ({|
                                                                     stags := NoInfo;
                                                                     str := "apply_result_udp_check" |}))))
                                                                     Directionless)
@@ -2852,8 +2798,7 @@ Definition ingress := DeclControl NoInfo
                                                                     str := "hdr" |})
                                                                     NoLocator)
                                                                     (TypTypeName
-                                                                    (BareName
-                                                                    {| 
+                                                                    ({|
                                                                     stags := NoInfo;
                                                                     str := "headers" |}))
                                                                     InOut)
@@ -2917,8 +2862,7 @@ Definition ingress := DeclControl NoInfo
                                                                     nil nil
                                                                     FunTable
                                                                     (TypTypeName
-                                                                    (BareName
-                                                                    {| 
+                                                                    ({|
                                                                     stags := NoInfo;
                                                                     str := "apply_result_icmp_check" |}))))
                                                                     Directionless)
@@ -2951,8 +2895,7 @@ Definition ingress := DeclControl NoInfo
                                   (TypFunction
                                    (MkFunctionType nil nil FunTable
                                         (TypTypeName
-                                         (BareName
-                                          {| stags := NoInfo;
+                                         ({| stags := NoInfo;
                                              str := "apply_result_set_egress" |}))))
                                   Directionless) nil nil) StmUnit)
                    (BlockEmpty NoInfo)))).
@@ -2960,10 +2903,10 @@ Definition ingress := DeclControl NoInfo
 Definition DeparserImpl := DeclControl NoInfo
     {| stags := NoInfo; str := "DeparserImpl" |} nil
     [(MkParameter false Directionless
-          (TypTypeName (BareName {| stags := NoInfo; str := "packet_out" |}))
+          (TypTypeName ({| stags := NoInfo; str := "packet_out" |}))
           None {| stags := NoInfo; str := "packet" |});
      (MkParameter false In
-          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          (TypTypeName ({| stags := NoInfo; str := "headers" |}))
           None {| stags := NoInfo; str := "hdr" |})] nil nil
     (BlockCons
          (MkStatement NoInfo
@@ -2976,8 +2919,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                     {| stags := NoInfo; str := "packet" |})
                                    NoLocator)
                                   (TypTypeName
-                                   (BareName
-                                    {| stags := NoInfo;
+                                   ({| stags := NoInfo;
                                        str := "packet_out" |}))
                                   Directionless)
                              {| stags := NoInfo; str := "emit" |})
@@ -2985,8 +2927,7 @@ Definition DeparserImpl := DeclControl NoInfo
                          (MkFunctionType [{| stags := NoInfo; str := "T2" |}]
                               [(MkParameter false In
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo; str := "T2" |}))
+                                     ({| stags := NoInfo; str := "T2" |}))
                                     None {| stags := NoInfo; str := "hdr" |})]
                               FunExtern TypVoid)) Directionless)
                    [(TypHeader
@@ -3005,8 +2946,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                       {| stags := NoInfo; str := "hdr" |})
                                      NoLocator)
                                     (TypTypeName
-                                     (BareName
-                                      {| stags := NoInfo; str := "headers" |}))
+                                     ({| stags := NoInfo; str := "headers" |}))
                                     In)
                                {| stags := NoInfo; str := "ethernet" |})
                           (TypHeader
@@ -3027,8 +2967,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                          {| stags := NoInfo;
                                             str := "packet" |}) NoLocator)
                                        (TypTypeName
-                                        (BareName
-                                         {| stags := NoInfo;
+                                        ({| stags := NoInfo;
                                             str := "packet_out" |}))
                                        Directionless)
                                   {| stags := NoInfo; str := "emit" |})
@@ -3037,8 +2976,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                    [{| stags := NoInfo; str := "T2" |}]
                                    [(MkParameter false In
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo; str := "T2" |}))
+                                          ({| stags := NoInfo; str := "T2" |}))
                                          None
                                          {| stags := NoInfo; str := "hdr" |})]
                                    FunExtern TypVoid)) Directionless)
@@ -3060,8 +2998,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                            {| stags := NoInfo;
                                               str := "hdr" |}) NoLocator)
                                          (TypTypeName
-                                          (BareName
-                                           {| stags := NoInfo;
+                                          ({| stags := NoInfo;
                                               str := "headers" |})) In)
                                     {| stags := NoInfo; str := "vlan_tag" |})
                                (TypHeader
@@ -3086,8 +3023,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                  str := "packet" |})
                                              NoLocator)
                                             (TypTypeName
-                                             (BareName
-                                              {| stags := NoInfo;
+                                             ({| stags := NoInfo;
                                                  str := "packet_out" |}))
                                             Directionless)
                                        {| stags := NoInfo; str := "emit" |})
@@ -3096,8 +3032,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                         [{| stags := NoInfo; str := "T2" |}]
                                         [(MkParameter false In
                                               (TypTypeName
-                                               (BareName
-                                                {| stags := NoInfo;
+                                               ({| stags := NoInfo;
                                                    str := "T2" |})) None
                                               {| stags := NoInfo;
                                                  str := "hdr" |})] FunExtern
@@ -3129,8 +3064,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                    str := "hdr" |})
                                                NoLocator)
                                               (TypTypeName
-                                               (BareName
-                                                {| stags := NoInfo;
+                                               ({| stags := NoInfo;
                                                    str := "headers" |})) In)
                                          {| stags := NoInfo; str := "ipv6" |})
                                     (TypHeader
@@ -3171,8 +3105,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                       str := "packet" |})
                                                   NoLocator)
                                                  (TypTypeName
-                                                  (BareName
-                                                   {| stags := NoInfo;
+                                                  ({| stags := NoInfo;
                                                       str := "packet_out" |}))
                                                  Directionless)
                                             {| stags := NoInfo;
@@ -3183,8 +3116,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                  str := "T2" |}]
                                              [(MkParameter false In
                                                    (TypTypeName
-                                                    (BareName
-                                                     {| stags := NoInfo;
+                                                    ({| stags := NoInfo;
                                                         str := "T2" |})) 
                                                    None
                                                    {| stags := NoInfo;
@@ -3234,8 +3166,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                         str := "hdr" |})
                                                     NoLocator)
                                                    (TypTypeName
-                                                    (BareName
-                                                     {| stags := NoInfo;
+                                                    ({| stags := NoInfo;
                                                         str := "headers" |}))
                                                    In)
                                               {| stags := NoInfo;
@@ -3290,8 +3221,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                            str := "packet" |})
                                                        NoLocator)
                                                       (TypTypeName
-                                                       (BareName
-                                                        {| stags := NoInfo;
+                                                       ({| stags := NoInfo;
                                                            str := "packet_out" |}))
                                                       Directionless)
                                                  {| stags := NoInfo;
@@ -3302,8 +3232,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                       str := "T2" |}]
                                                   [(MkParameter false In
                                                         (TypTypeName
-                                                         (BareName
-                                                          {| stags := NoInfo;
+                                                         ({| stags := NoInfo;
                                                              str := "T2" |}))
                                                         None
                                                         {| stags := NoInfo;
@@ -3333,8 +3262,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                              str := "hdr" |})
                                                          NoLocator)
                                                         (TypTypeName
-                                                         (BareName
-                                                          {| stags := NoInfo;
+                                                         ({| stags := NoInfo;
                                                              str := "headers" |}))
                                                         In)
                                                    {| stags := NoInfo;
@@ -3365,8 +3293,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                                 str := "packet" |})
                                                             NoLocator)
                                                            (TypTypeName
-                                                            (BareName
-                                                             {| stags := NoInfo;
+                                                            ({| stags := NoInfo;
                                                                 str := "packet_out" |}))
                                                            Directionless)
                                                       {| stags := NoInfo;
@@ -3377,8 +3304,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                            str := "T2" |}]
                                                        [(MkParameter false In
                                                              (TypTypeName
-                                                              (BareName
-                                                               {| stags := NoInfo;
+                                                              ({| stags := NoInfo;
                                                                   str := "T2" |}))
                                                              None
                                                              {| stags := NoInfo;
@@ -3426,8 +3352,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                                   str := "hdr" |})
                                                               NoLocator)
                                                              (TypTypeName
-                                                              (BareName
-                                                               {| stags := NoInfo;
+                                                              ({| stags := NoInfo;
                                                                   str := "headers" |}))
                                                              In)
                                                         {| stags := NoInfo;
@@ -3478,8 +3403,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                                   str := "packet" |})
                                                                  NoLocator)
                                                                 (TypTypeName
-                                                                 (BareName
-                                                                  {| 
+                                                                 ({|
                                                                   stags := NoInfo;
                                                                   str := "packet_out" |}))
                                                                 Directionless)
@@ -3492,8 +3416,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                             [(MkParameter
                                                                   false In
                                                                   (TypTypeName
-                                                                   (BareName
-                                                                    {| 
+                                                                   ({|
                                                                     stags := NoInfo;
                                                                     str := "T2" |}))
                                                                   None
@@ -3522,8 +3445,7 @@ Definition DeparserImpl := DeclControl NoInfo
                                                                     str := "hdr" |})
                                                                    NoLocator)
                                                                   (TypTypeName
-                                                                   (BareName
-                                                                    {| 
+                                                                   ({|
                                                                     stags := NoInfo;
                                                                     str := "headers" |}))
                                                                   In)
@@ -3542,26 +3464,26 @@ Definition DeparserImpl := DeclControl NoInfo
 Definition verifyChecksum := DeclControl NoInfo
     {| stags := NoInfo; str := "verifyChecksum" |} nil
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          (TypTypeName ({| stags := NoInfo; str := "headers" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          (TypTypeName ({| stags := NoInfo; str := "metadata" |}))
           None {| stags := NoInfo; str := "meta" |})] nil nil
     (BlockEmpty NoInfo).
 
 Definition computeChecksum := DeclControl NoInfo
     {| stags := NoInfo; str := "computeChecksum" |} nil
     [(MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          (TypTypeName ({| stags := NoInfo; str := "headers" |}))
           None {| stags := NoInfo; str := "hdr" |});
      (MkParameter false InOut
-          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          (TypTypeName ({| stags := NoInfo; str := "metadata" |}))
           None {| stags := NoInfo; str := "meta" |})] nil nil
     (BlockEmpty NoInfo).
 
 Definition main := DeclInstantiation NoInfo
     (TypSpecializedType
-         (TypTypeName (BareName {| stags := NoInfo; str := "V1Switch" |}))
+         (TypTypeName ({| stags := NoInfo; str := "V1Switch" |}))
          [(TypStruct
            [( {| stags := NoInfo; str := "ethernet" |},
               (TypHeader
@@ -3634,7 +3556,7 @@ Definition main := DeclInstantiation NoInfo
           (ExpNamelessInstantiation
                (TypSpecializedType
                     (TypTypeName
-                     (BareName {| stags := NoInfo; str := "ParserImpl" |}))
+                     ({| stags := NoInfo; str := "ParserImpl" |}))
                     nil) nil)
           (TypParser
            (MkControlType nil
@@ -3797,8 +3719,7 @@ Definition main := DeclInstantiation NoInfo
           (ExpNamelessInstantiation
                (TypSpecializedType
                     (TypTypeName
-                     (BareName
-                      {| stags := NoInfo; str := "verifyChecksum" |})) nil)
+                     ({| stags := NoInfo; str := "verifyChecksum" |})) nil)
                nil)
           (TypControl
            (MkControlType nil
@@ -3920,7 +3841,7 @@ Definition main := DeclInstantiation NoInfo
           (ExpNamelessInstantiation
                (TypSpecializedType
                     (TypTypeName
-                     (BareName {| stags := NoInfo; str := "ingress" |})) nil)
+                     ({| stags := NoInfo; str := "ingress" |})) nil)
                nil)
           (TypControl
            (MkControlType nil
@@ -4080,7 +4001,7 @@ Definition main := DeclInstantiation NoInfo
           (ExpNamelessInstantiation
                (TypSpecializedType
                     (TypTypeName
-                     (BareName {| stags := NoInfo; str := "egress" |})) nil)
+                     ({| stags := NoInfo; str := "egress" |})) nil)
                nil)
           (TypControl
            (MkControlType nil
@@ -4240,8 +4161,7 @@ Definition main := DeclInstantiation NoInfo
           (ExpNamelessInstantiation
                (TypSpecializedType
                     (TypTypeName
-                     (BareName
-                      {| stags := NoInfo; str := "computeChecksum" |})) nil)
+                     ({| stags := NoInfo; str := "computeChecksum" |})) nil)
                nil)
           (TypControl
            (MkControlType nil
@@ -4363,7 +4283,7 @@ Definition main := DeclInstantiation NoInfo
           (ExpNamelessInstantiation
                (TypSpecializedType
                     (TypTypeName
-                     (BareName {| stags := NoInfo; str := "DeparserImpl" |}))
+                     ({| stags := NoInfo; str := "DeparserImpl" |}))
                     nil) nil)
           (TypControl
            (MkControlType nil

--- a/deps/poulet4/lib/LightExamples/MultiProtocol.v
+++ b/deps/poulet4/lib/LightExamples/MultiProtocol.v
@@ -1,0 +1,4497 @@
+Require Import Poulet4.P4defs.
+Open Scope string_scope.
+
+Import ListNotations.
+
+Definition decl'1 := DeclError NoInfo
+    [{| stags := NoInfo; str := "NoError" |};
+     {| stags := NoInfo; str := "PacketTooShort" |};
+     {| stags := NoInfo; str := "NoMatch" |};
+     {| stags := NoInfo; str := "StackOutOfBounds" |};
+     {| stags := NoInfo; str := "HeaderTooShort" |};
+     {| stags := NoInfo; str := "ParserTimeout" |};
+     {| stags := NoInfo; str := "ParserInvalidArgument" |}].
+
+Definition packet_in := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "packet_in" |} nil
+    [(ProtoMethod NoInfo (TypBit 32%N) {| stags := NoInfo; str := "length" |}
+          nil nil);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "advance" |} nil
+          [(MkParameter false In (TypBit 32%N) None
+                {| stags := NoInfo; str := "sizeInBits" |})]);
+     (ProtoMethod NoInfo
+          (TypTypeName (BareName {| stags := NoInfo; str := "T1" |}))
+          {| stags := NoInfo; str := "lookahead" |}
+          [{| stags := NoInfo; str := "T1" |}] nil);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "extract" |}
+          [{| stags := NoInfo; str := "T0" |}]
+          [(MkParameter false Out
+                (TypTypeName (BareName {| stags := NoInfo; str := "T0" |}))
+                None {| stags := NoInfo; str := "variableSizeHeader" |});
+           (MkParameter false In (TypBit 32%N) None
+                {| stags := NoInfo; str := "variableFieldSizeInBits" |})]);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "extract" |}
+          [{| stags := NoInfo; str := "T" |}]
+          [(MkParameter false Out
+                (TypTypeName (BareName {| stags := NoInfo; str := "T" |}))
+                None {| stags := NoInfo; str := "hdr" |})])].
+
+Definition packet_out := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "packet_out" |} nil
+    [(ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "emit" |}
+          [{| stags := NoInfo; str := "T2" |}]
+          [(MkParameter false In
+                (TypTypeName (BareName {| stags := NoInfo; str := "T2" |}))
+                None {| stags := NoInfo; str := "hdr" |})])].
+
+Definition verify'check'toSignal := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "verify" |} nil
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "check" |});
+     (MkParameter false In TypError None
+          {| stags := NoInfo; str := "toSignal" |})].
+
+Definition NoAction := DeclAction NoInfo
+    {| stags := NoInfo; str := "NoAction" |} nil nil (BlockEmpty NoInfo).
+
+Definition decl'2 := DeclMatchKind NoInfo
+    [{| stags := NoInfo; str := "exact" |};
+     {| stags := NoInfo; str := "ternary" |};
+     {| stags := NoInfo; str := "lpm" |}].
+
+Definition decl'3 := DeclMatchKind NoInfo
+    [{| stags := NoInfo; str := "range" |};
+     {| stags := NoInfo; str := "optional" |};
+     {| stags := NoInfo; str := "selector" |}].
+
+Definition standard_metadata_t := DeclStruct NoInfo
+    {| stags := NoInfo; str := "standard_metadata_t" |}
+    [(MkDeclarationField NoInfo (TypBit 9%N)
+          {| stags := NoInfo; str := "ingress_port" |});
+     (MkDeclarationField NoInfo (TypBit 9%N)
+          {| stags := NoInfo; str := "egress_spec" |});
+     (MkDeclarationField NoInfo (TypBit 9%N)
+          {| stags := NoInfo; str := "egress_port" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "instance_type" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "packet_length" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "enq_timestamp" |});
+     (MkDeclarationField NoInfo (TypBit 19%N)
+          {| stags := NoInfo; str := "enq_qdepth" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "deq_timedelta" |});
+     (MkDeclarationField NoInfo (TypBit 19%N)
+          {| stags := NoInfo; str := "deq_qdepth" |});
+     (MkDeclarationField NoInfo (TypBit 48%N)
+          {| stags := NoInfo; str := "ingress_global_timestamp" |});
+     (MkDeclarationField NoInfo (TypBit 48%N)
+          {| stags := NoInfo; str := "egress_global_timestamp" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "mcast_grp" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "egress_rid" |});
+     (MkDeclarationField NoInfo (TypBit 1%N)
+          {| stags := NoInfo; str := "checksum_error" |});
+     (MkDeclarationField NoInfo TypError
+          {| stags := NoInfo; str := "parser_error" |});
+     (MkDeclarationField NoInfo (TypBit 3%N)
+          {| stags := NoInfo; str := "priority" |})].
+
+Definition CounterType := DeclEnum NoInfo
+    {| stags := NoInfo; str := "CounterType" |}
+    [{| stags := NoInfo; str := "packets" |};
+     {| stags := NoInfo; str := "bytes" |};
+     {| stags := NoInfo; str := "packets_and_bytes" |}].
+
+Definition MeterType := DeclEnum NoInfo
+    {| stags := NoInfo; str := "MeterType" |}
+    [{| stags := NoInfo; str := "packets" |};
+     {| stags := NoInfo; str := "bytes" |}].
+
+Definition counter := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "counter" |} nil
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "counter" |}
+          [(MkParameter false Directionless (TypBit 32%N) None
+                {| stags := NoInfo; str := "size" |});
+           (MkParameter false Directionless
+                (TypTypeName
+                 (BareName {| stags := NoInfo; str := "CounterType" |})) 
+                None {| stags := NoInfo; str := "type" |})]);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "count" |} nil
+          [(MkParameter false In (TypBit 32%N) None
+                {| stags := NoInfo; str := "index" |})])].
+
+Definition direct_counter := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "direct_counter" |} nil
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "direct_counter" |}
+          [(MkParameter false Directionless
+                (TypTypeName
+                 (BareName {| stags := NoInfo; str := "CounterType" |})) 
+                None {| stags := NoInfo; str := "type" |})]);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "count" |} nil
+          nil)].
+
+Definition meter := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "meter" |} nil
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "meter" |}
+          [(MkParameter false Directionless (TypBit 32%N) None
+                {| stags := NoInfo; str := "size" |});
+           (MkParameter false Directionless
+                (TypTypeName
+                 (BareName {| stags := NoInfo; str := "MeterType" |})) 
+                None {| stags := NoInfo; str := "type" |})]);
+     (ProtoMethod NoInfo TypVoid
+          {| stags := NoInfo; str := "execute_meter" |}
+          [{| stags := NoInfo; str := "T3" |}]
+          [(MkParameter false In (TypBit 32%N) None
+                {| stags := NoInfo; str := "index" |});
+           (MkParameter false Out
+                (TypTypeName (BareName {| stags := NoInfo; str := "T3" |}))
+                None {| stags := NoInfo; str := "result" |})])].
+
+Definition direct_meter := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "direct_meter" |}
+    [{| stags := NoInfo; str := "T4" |}]
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "direct_meter" |}
+          [(MkParameter false Directionless
+                (TypTypeName
+                 (BareName {| stags := NoInfo; str := "MeterType" |})) 
+                None {| stags := NoInfo; str := "type" |})]);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "read" |} nil
+          [(MkParameter false Out
+                (TypTypeName (BareName {| stags := NoInfo; str := "T4" |}))
+                None {| stags := NoInfo; str := "result" |})])].
+
+Definition register := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "register" |}
+    [{| stags := NoInfo; str := "T5" |}]
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "register" |}
+          [(MkParameter false Directionless (TypBit 32%N) None
+                {| stags := NoInfo; str := "size" |})]);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "write" |} nil
+          [(MkParameter false In (TypBit 32%N) None
+                {| stags := NoInfo; str := "index" |});
+           (MkParameter false In
+                (TypTypeName (BareName {| stags := NoInfo; str := "T5" |}))
+                None {| stags := NoInfo; str := "value" |})]);
+     (ProtoMethod NoInfo TypVoid {| stags := NoInfo; str := "read" |} nil
+          [(MkParameter false Out
+                (TypTypeName (BareName {| stags := NoInfo; str := "T5" |}))
+                None {| stags := NoInfo; str := "result" |});
+           (MkParameter false In (TypBit 32%N) None
+                {| stags := NoInfo; str := "index" |})])].
+
+Definition action_profile := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "action_profile" |} nil
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "action_profile" |}
+          [(MkParameter false Directionless (TypBit 32%N) None
+                {| stags := NoInfo; str := "size" |})])].
+
+Definition random'result'lo'hi := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "random" |}
+    [{| stags := NoInfo; str := "T6" |}]
+    [(MkParameter false Out
+          (TypTypeName (BareName {| stags := NoInfo; str := "T6" |})) 
+          None {| stags := NoInfo; str := "result" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T6" |})) 
+          None {| stags := NoInfo; str := "lo" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T6" |})) 
+          None {| stags := NoInfo; str := "hi" |})].
+
+Definition digest'receiver'data := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "digest" |}
+    [{| stags := NoInfo; str := "T7" |}]
+    [(MkParameter false In (TypBit 32%N) None
+          {| stags := NoInfo; str := "receiver" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T7" |})) 
+          None {| stags := NoInfo; str := "data" |})].
+
+Definition HashAlgorithm := DeclEnum NoInfo
+    {| stags := NoInfo; str := "HashAlgorithm" |}
+    [{| stags := NoInfo; str := "crc32" |};
+     {| stags := NoInfo; str := "crc32_custom" |};
+     {| stags := NoInfo; str := "crc16" |};
+     {| stags := NoInfo; str := "crc16_custom" |};
+     {| stags := NoInfo; str := "random" |};
+     {| stags := NoInfo; str := "identity" |};
+     {| stags := NoInfo; str := "csum16" |};
+     {| stags := NoInfo; str := "xor16" |}].
+
+Definition mark_to_drop := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "mark_to_drop" |} nil nil.
+
+Definition mark_to_drop'standard_metadata := DeclExternFunction NoInfo
+    TypVoid {| stags := NoInfo; str := "mark_to_drop" |} nil
+    [(MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})].
+
+Definition hash'result'algo'base'data'max := DeclExternFunction NoInfo
+    TypVoid {| stags := NoInfo; str := "hash" |}
+    [{| stags := NoInfo; str := "O" |}; {| stags := NoInfo; str := "T8" |};
+     {| stags := NoInfo; str := "D" |}; {| stags := NoInfo; str := "M" |}]
+    [(MkParameter false Out
+          (TypTypeName (BareName {| stags := NoInfo; str := "O" |})) 
+          None {| stags := NoInfo; str := "result" |});
+     (MkParameter false In
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+          None {| stags := NoInfo; str := "algo" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T8" |})) 
+          None {| stags := NoInfo; str := "base" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "D" |})) 
+          None {| stags := NoInfo; str := "data" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "M" |})) 
+          None {| stags := NoInfo; str := "max" |})].
+
+Definition action_selector := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "action_selector" |} nil
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "action_selector" |}
+          [(MkParameter false Directionless
+                (TypTypeName
+                 (BareName {| stags := NoInfo; str := "HashAlgorithm" |}))
+                None {| stags := NoInfo; str := "algorithm" |});
+           (MkParameter false Directionless (TypBit 32%N) None
+                {| stags := NoInfo; str := "size" |});
+           (MkParameter false Directionless (TypBit 32%N) None
+                {| stags := NoInfo; str := "outputWidth" |})])].
+
+Definition CloneType := DeclEnum NoInfo
+    {| stags := NoInfo; str := "CloneType" |}
+    [{| stags := NoInfo; str := "I2E" |};
+     {| stags := NoInfo; str := "E2E" |}].
+
+Definition Checksum16 := DeclExternObject NoInfo
+    {| stags := NoInfo; str := "Checksum16" |} nil
+    [(ProtoConstructor NoInfo {| stags := NoInfo; str := "Checksum16" |} nil);
+     (ProtoMethod NoInfo (TypBit 16%N) {| stags := NoInfo; str := "get" |}
+          [{| stags := NoInfo; str := "D9" |}]
+          [(MkParameter false In
+                (TypTypeName (BareName {| stags := NoInfo; str := "D9" |}))
+                None {| stags := NoInfo; str := "data" |})])].
+
+Definition verify_checksum'condition'data'checksum'algo := DeclExternFunction
+    NoInfo TypVoid {| stags := NoInfo; str := "verify_checksum" |}
+    [{| stags := NoInfo; str := "T10" |};
+     {| stags := NoInfo; str := "O11" |}]
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "condition" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T10" |})) 
+          None {| stags := NoInfo; str := "data" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "O11" |})) 
+          None {| stags := NoInfo; str := "checksum" |});
+     (MkParameter false Directionless
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+          None {| stags := NoInfo; str := "algo" |})].
+
+Definition update_checksum'condition'data'checksum'algo := DeclExternFunction
+    NoInfo TypVoid {| stags := NoInfo; str := "update_checksum" |}
+    [{| stags := NoInfo; str := "T12" |};
+     {| stags := NoInfo; str := "O13" |}]
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "condition" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T12" |})) 
+          None {| stags := NoInfo; str := "data" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "O13" |})) 
+          None {| stags := NoInfo; str := "checksum" |});
+     (MkParameter false Directionless
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+          None {| stags := NoInfo; str := "algo" |})].
+
+Definition verify_checksum_with_payload'condition'data'checksum'algo := DeclExternFunction
+    NoInfo TypVoid
+    {| stags := NoInfo; str := "verify_checksum_with_payload" |}
+    [{| stags := NoInfo; str := "T14" |};
+     {| stags := NoInfo; str := "O15" |}]
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "condition" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T14" |})) 
+          None {| stags := NoInfo; str := "data" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "O15" |})) 
+          None {| stags := NoInfo; str := "checksum" |});
+     (MkParameter false Directionless
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+          None {| stags := NoInfo; str := "algo" |})].
+
+Definition update_checksum_with_payload'condition'data'checksum'algo := DeclExternFunction
+    NoInfo TypVoid
+    {| stags := NoInfo; str := "update_checksum_with_payload" |}
+    [{| stags := NoInfo; str := "T16" |};
+     {| stags := NoInfo; str := "O17" |}]
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "condition" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T16" |})) 
+          None {| stags := NoInfo; str := "data" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "O17" |})) 
+          None {| stags := NoInfo; str := "checksum" |});
+     (MkParameter false Directionless
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "HashAlgorithm" |})) 
+          None {| stags := NoInfo; str := "algo" |})].
+
+Definition resubmit'data := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "resubmit" |}
+    [{| stags := NoInfo; str := "T18" |}]
+    [(MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T18" |})) 
+          None {| stags := NoInfo; str := "data" |})].
+
+Definition recirculate'data := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "recirculate" |}
+    [{| stags := NoInfo; str := "T19" |}]
+    [(MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T19" |})) 
+          None {| stags := NoInfo; str := "data" |})].
+
+Definition clone'type'session := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "clone" |} nil
+    [(MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "CloneType" |}))
+          None {| stags := NoInfo; str := "type" |});
+     (MkParameter false In (TypBit 32%N) None
+          {| stags := NoInfo; str := "session" |})].
+
+Definition clone3'type'session'data := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "clone3" |}
+    [{| stags := NoInfo; str := "T20" |}]
+    [(MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "CloneType" |}))
+          None {| stags := NoInfo; str := "type" |});
+     (MkParameter false In (TypBit 32%N) None
+          {| stags := NoInfo; str := "session" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T20" |})) 
+          None {| stags := NoInfo; str := "data" |})].
+
+Definition truncate'length := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "truncate" |} nil
+    [(MkParameter false In (TypBit 32%N) None
+          {| stags := NoInfo; str := "length" |})].
+
+Definition assert'check := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "assert" |} nil
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "check" |})].
+
+Definition assume'check := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "assume" |} nil
+    [(MkParameter false In TypBool None
+          {| stags := NoInfo; str := "check" |})].
+
+Definition log_msg'msg := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "log_msg" |} nil
+    [(MkParameter false Directionless TypString None
+          {| stags := NoInfo; str := "msg" |})].
+
+Definition log_msg'msg'data := DeclExternFunction NoInfo TypVoid
+    {| stags := NoInfo; str := "log_msg" |}
+    [{| stags := NoInfo; str := "T21" |}]
+    [(MkParameter false Directionless TypString None
+          {| stags := NoInfo; str := "msg" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "T21" |})) 
+          None {| stags := NoInfo; str := "data" |})].
+
+Definition Parser := DeclParserType NoInfo
+    {| stags := NoInfo; str := "Parser" |}
+    [{| stags := NoInfo; str := "H" |}; {| stags := NoInfo; str := "M22" |}]
+    [(MkParameter false Directionless
+          (TypTypeName (BareName {| stags := NoInfo; str := "packet_in" |}))
+          None {| stags := NoInfo; str := "b" |});
+     (MkParameter false Out
+          (TypTypeName (BareName {| stags := NoInfo; str := "H" |})) 
+          None {| stags := NoInfo; str := "parsedHdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "M22" |})) 
+          None {| stags := NoInfo; str := "meta" |});
+     (MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})].
+
+Definition VerifyChecksum := DeclControlType NoInfo
+    {| stags := NoInfo; str := "VerifyChecksum" |}
+    [{| stags := NoInfo; str := "H23" |};
+     {| stags := NoInfo; str := "M24" |}]
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "H23" |})) 
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "M24" |})) 
+          None {| stags := NoInfo; str := "meta" |})].
+
+Definition Ingress := DeclControlType NoInfo
+    {| stags := NoInfo; str := "Ingress" |}
+    [{| stags := NoInfo; str := "H25" |};
+     {| stags := NoInfo; str := "M26" |}]
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "H25" |})) 
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "M26" |})) 
+          None {| stags := NoInfo; str := "meta" |});
+     (MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})].
+
+Definition Egress := DeclControlType NoInfo
+    {| stags := NoInfo; str := "Egress" |}
+    [{| stags := NoInfo; str := "H27" |};
+     {| stags := NoInfo; str := "M28" |}]
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "H27" |})) 
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "M28" |})) 
+          None {| stags := NoInfo; str := "meta" |});
+     (MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})].
+
+Definition ComputeChecksum := DeclControlType NoInfo
+    {| stags := NoInfo; str := "ComputeChecksum" |}
+    [{| stags := NoInfo; str := "H29" |};
+     {| stags := NoInfo; str := "M30" |}]
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "H29" |})) 
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "M30" |})) 
+          None {| stags := NoInfo; str := "meta" |})].
+
+Definition Deparser := DeclControlType NoInfo
+    {| stags := NoInfo; str := "Deparser" |}
+    [{| stags := NoInfo; str := "H31" |}]
+    [(MkParameter false Directionless
+          (TypTypeName (BareName {| stags := NoInfo; str := "packet_out" |}))
+          None {| stags := NoInfo; str := "b" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "H31" |})) 
+          None {| stags := NoInfo; str := "hdr" |})].
+
+Definition V1Switch := DeclPackageType NoInfo
+    {| stags := NoInfo; str := "V1Switch" |}
+    [{| stags := NoInfo; str := "H32" |};
+     {| stags := NoInfo; str := "M33" |}]
+    [(MkParameter false Directionless
+          (TypSpecializedType
+               (TypTypeName
+                (BareName {| stags := NoInfo; str := "Parser" |}))
+               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
+                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+          None {| stags := NoInfo; str := "p" |});
+     (MkParameter false Directionless
+          (TypSpecializedType
+               (TypTypeName
+                (BareName {| stags := NoInfo; str := "VerifyChecksum" |}))
+               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
+                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+          None {| stags := NoInfo; str := "vr" |});
+     (MkParameter false Directionless
+          (TypSpecializedType
+               (TypTypeName
+                (BareName {| stags := NoInfo; str := "Ingress" |}))
+               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
+                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+          None {| stags := NoInfo; str := "ig" |});
+     (MkParameter false Directionless
+          (TypSpecializedType
+               (TypTypeName
+                (BareName {| stags := NoInfo; str := "Egress" |}))
+               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
+                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+          None {| stags := NoInfo; str := "eg" |});
+     (MkParameter false Directionless
+          (TypSpecializedType
+               (TypTypeName
+                (BareName {| stags := NoInfo; str := "ComputeChecksum" |}))
+               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}));
+                (TypTypeName (BareName {| stags := NoInfo; str := "M33" |}))])
+          None {| stags := NoInfo; str := "ck" |});
+     (MkParameter false Directionless
+          (TypSpecializedType
+               (TypTypeName
+                (BareName {| stags := NoInfo; str := "Deparser" |}))
+               [(TypTypeName (BareName {| stags := NoInfo; str := "H32" |}))])
+          None {| stags := NoInfo; str := "dep" |})].
+
+Definition ingress_metadata_t := DeclStruct NoInfo
+    {| stags := NoInfo; str := "ingress_metadata_t" |}
+    [(MkDeclarationField NoInfo (TypBit 1%N)
+          {| stags := NoInfo; str := "drop" |});
+     (MkDeclarationField NoInfo (TypBit 9%N)
+          {| stags := NoInfo; str := "egress_port" |});
+     (MkDeclarationField NoInfo (TypBit 4%N)
+          {| stags := NoInfo; str := "packet_type" |})].
+
+Definition ethernet_t := DeclHeader NoInfo
+    {| stags := NoInfo; str := "ethernet_t" |}
+    [(MkDeclarationField NoInfo (TypBit 48%N)
+          {| stags := NoInfo; str := "dstAddr" |});
+     (MkDeclarationField NoInfo (TypBit 48%N)
+          {| stags := NoInfo; str := "srcAddr" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "etherType" |})].
+
+Definition icmp_t := DeclHeader NoInfo {| stags := NoInfo; str := "icmp_t" |}
+    [(MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "typeCode" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "hdrChecksum" |})].
+
+Definition ipv4_t := DeclHeader NoInfo {| stags := NoInfo; str := "ipv4_t" |}
+    [(MkDeclarationField NoInfo (TypBit 4%N)
+          {| stags := NoInfo; str := "version" |});
+     (MkDeclarationField NoInfo (TypBit 4%N)
+          {| stags := NoInfo; str := "ihl" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "diffserv" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "totalLen" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "identification" |});
+     (MkDeclarationField NoInfo (TypBit 3%N)
+          {| stags := NoInfo; str := "flags" |});
+     (MkDeclarationField NoInfo (TypBit 13%N)
+          {| stags := NoInfo; str := "fragOffset" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "ttl" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "protocol" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "hdrChecksum" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "srcAddr" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "dstAddr" |})].
+
+Definition ipv6_t := DeclHeader NoInfo {| stags := NoInfo; str := "ipv6_t" |}
+    [(MkDeclarationField NoInfo (TypBit 4%N)
+          {| stags := NoInfo; str := "version" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "trafficClass" |});
+     (MkDeclarationField NoInfo (TypBit 20%N)
+          {| stags := NoInfo; str := "flowLabel" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "payloadLen" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "nextHdr" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "hopLimit" |});
+     (MkDeclarationField NoInfo (TypBit 128%N)
+          {| stags := NoInfo; str := "srcAddr" |});
+     (MkDeclarationField NoInfo (TypBit 128%N)
+          {| stags := NoInfo; str := "dstAddr" |})].
+
+Definition tcp_t := DeclHeader NoInfo {| stags := NoInfo; str := "tcp_t" |}
+    [(MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "srcPort" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "dstPort" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "seqNo" |});
+     (MkDeclarationField NoInfo (TypBit 32%N)
+          {| stags := NoInfo; str := "ackNo" |});
+     (MkDeclarationField NoInfo (TypBit 4%N)
+          {| stags := NoInfo; str := "dataOffset" |});
+     (MkDeclarationField NoInfo (TypBit 4%N)
+          {| stags := NoInfo; str := "res" |});
+     (MkDeclarationField NoInfo (TypBit 8%N)
+          {| stags := NoInfo; str := "flags" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "window" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "checksum" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "urgentPtr" |})].
+
+Definition udp_t := DeclHeader NoInfo {| stags := NoInfo; str := "udp_t" |}
+    [(MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "srcPort" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "dstPort" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "length_" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "checksum" |})].
+
+Definition vlan_tag_t := DeclHeader NoInfo
+    {| stags := NoInfo; str := "vlan_tag_t" |}
+    [(MkDeclarationField NoInfo (TypBit 3%N)
+          {| stags := NoInfo; str := "pcp" |});
+     (MkDeclarationField NoInfo (TypBit 1%N)
+          {| stags := NoInfo; str := "cfi" |});
+     (MkDeclarationField NoInfo (TypBit 12%N)
+          {| stags := NoInfo; str := "vid" |});
+     (MkDeclarationField NoInfo (TypBit 16%N)
+          {| stags := NoInfo; str := "etherType" |})].
+
+Definition metadata := DeclStruct NoInfo
+    {| stags := NoInfo; str := "metadata" |}
+    [(MkDeclarationField NoInfo
+          (TypStruct
+           [( {| stags := NoInfo; str := "drop" |}, (TypBit 1%N) );
+            ( {| stags := NoInfo; str := "egress_port" |}, (TypBit 9%N) );
+            ( {| stags := NoInfo; str := "packet_type" |}, (TypBit 4%N) )])
+          {| stags := NoInfo; str := "ing_metadata" |})].
+
+Definition headers := DeclStruct NoInfo
+    {| stags := NoInfo; str := "headers" |}
+    [(MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "dstAddr" |}, (TypBit 48%N) );
+            ( {| stags := NoInfo; str := "srcAddr" |}, (TypBit 48%N) );
+            ( {| stags := NoInfo; str := "etherType" |}, (TypBit 16%N) )])
+          {| stags := NoInfo; str := "ethernet" |});
+     (MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "typeCode" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "hdrChecksum" |}, (TypBit 16%N) )])
+          {| stags := NoInfo; str := "icmp" |});
+     (MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "version" |}, (TypBit 4%N) );
+            ( {| stags := NoInfo; str := "ihl" |}, (TypBit 4%N) );
+            ( {| stags := NoInfo; str := "diffserv" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "totalLen" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "identification" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "flags" |}, (TypBit 3%N) );
+            ( {| stags := NoInfo; str := "fragOffset" |}, (TypBit 13%N) );
+            ( {| stags := NoInfo; str := "ttl" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "protocol" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "hdrChecksum" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "srcAddr" |}, (TypBit 32%N) );
+            ( {| stags := NoInfo; str := "dstAddr" |}, (TypBit 32%N) )])
+          {| stags := NoInfo; str := "ipv4" |});
+     (MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "version" |}, (TypBit 4%N) );
+            ( {| stags := NoInfo; str := "trafficClass" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "flowLabel" |}, (TypBit 20%N) );
+            ( {| stags := NoInfo; str := "payloadLen" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "nextHdr" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "hopLimit" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "srcAddr" |}, (TypBit 128%N) );
+            ( {| stags := NoInfo; str := "dstAddr" |}, (TypBit 128%N) )])
+          {| stags := NoInfo; str := "ipv6" |});
+     (MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "srcPort" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "dstPort" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "seqNo" |}, (TypBit 32%N) );
+            ( {| stags := NoInfo; str := "ackNo" |}, (TypBit 32%N) );
+            ( {| stags := NoInfo; str := "dataOffset" |}, (TypBit 4%N) );
+            ( {| stags := NoInfo; str := "res" |}, (TypBit 4%N) );
+            ( {| stags := NoInfo; str := "flags" |}, (TypBit 8%N) );
+            ( {| stags := NoInfo; str := "window" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "checksum" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "urgentPtr" |}, (TypBit 16%N) )])
+          {| stags := NoInfo; str := "tcp" |});
+     (MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "srcPort" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "dstPort" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "length_" |}, (TypBit 16%N) );
+            ( {| stags := NoInfo; str := "checksum" |}, (TypBit 16%N) )])
+          {| stags := NoInfo; str := "udp" |});
+     (MkDeclarationField NoInfo
+          (TypHeader
+           [( {| stags := NoInfo; str := "pcp" |}, (TypBit 3%N) );
+            ( {| stags := NoInfo; str := "cfi" |}, (TypBit 1%N) );
+            ( {| stags := NoInfo; str := "vid" |}, (TypBit 12%N) );
+            ( {| stags := NoInfo; str := "etherType" |}, (TypBit 16%N) )])
+          {| stags := NoInfo; str := "vlan_tag" |})].
+
+Definition ParserImpl := DeclParser NoInfo
+    {| stags := NoInfo; str := "ParserImpl" |} nil
+    [(MkParameter false Directionless
+          (TypTypeName (BareName {| stags := NoInfo; str := "packet_in" |}))
+          None {| stags := NoInfo; str := "packet" |});
+     (MkParameter false Out
+          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          None {| stags := NoInfo; str := "meta" |});
+     (MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})] nil nil
+    [(MkParserState NoInfo {| stags := NoInfo; str := "parse_icmp" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "typeCode" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "hdrChecksum" |},
+                          (TypBit 16%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "icmp" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "typeCode" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "hdrChecksum" |},
+                                (TypBit 16%N) )]) Directionless))]) StmUnit)]
+          (ParserDirect NoInfo {| stags := NoInfo; str := "accept" |}));
+     (MkParserState NoInfo {| stags := NoInfo; str := "parse_ipv4" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "version" |},
+                          (TypBit 4%N) );
+                        ( {| stags := NoInfo; str := "ihl" |}, (TypBit 4%N) );
+                        ( {| stags := NoInfo; str := "diffserv" |},
+                          (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "totalLen" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "identification" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "flags" |},
+                          (TypBit 3%N) );
+                        ( {| stags := NoInfo; str := "fragOffset" |},
+                          (TypBit 13%N) );
+                        ( {| stags := NoInfo; str := "ttl" |}, (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "protocol" |},
+                          (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "hdrChecksum" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "srcAddr" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "dstAddr" |},
+                          (TypBit 32%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "ipv4" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "version" |},
+                                (TypBit 4%N) );
+                              ( {| stags := NoInfo; str := "ihl" |},
+                                (TypBit 4%N) );
+                              ( {| stags := NoInfo; str := "diffserv" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "totalLen" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo;
+                                   str := "identification" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "flags" |},
+                                (TypBit 3%N) );
+                              ( {| stags := NoInfo; str := "fragOffset" |},
+                                (TypBit 13%N) );
+                              ( {| stags := NoInfo; str := "ttl" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "protocol" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "hdrChecksum" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "srcAddr" |},
+                                (TypBit 32%N) );
+                              ( {| stags := NoInfo; str := "dstAddr" |},
+                                (TypBit 32%N) )]) Directionless))]) StmUnit)]
+          (ParserSelect NoInfo
+               [(MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) Out)
+                                    {| stags := NoInfo; str := "ipv4" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "version" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "ihl" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "diffserv" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "totalLen" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "identification" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "flags" |},
+                                   (TypBit 3%N) );
+                                 ( {| stags := NoInfo; str := "fragOffset" |},
+                                   (TypBit 13%N) );
+                                 ( {| stags := NoInfo; str := "ttl" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "protocol" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "hdrChecksum" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 32%N) );
+                                 ( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 32%N) )]) Directionless)
+                          {| stags := NoInfo; str := "fragOffset" |})
+                     (TypBit 13%N) Directionless);
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) Out)
+                                    {| stags := NoInfo; str := "ipv4" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "version" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "ihl" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "diffserv" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "totalLen" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "identification" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "flags" |},
+                                   (TypBit 3%N) );
+                                 ( {| stags := NoInfo; str := "fragOffset" |},
+                                   (TypBit 13%N) );
+                                 ( {| stags := NoInfo; str := "ttl" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "protocol" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "hdrChecksum" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 32%N) );
+                                 ( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 32%N) )]) Directionless)
+                          {| stags := NoInfo; str := "ihl" |}) (TypBit 4%N)
+                     Directionless);
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) Out)
+                                    {| stags := NoInfo; str := "ipv4" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "version" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "ihl" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "diffserv" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "totalLen" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "identification" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "flags" |},
+                                   (TypBit 3%N) );
+                                 ( {| stags := NoInfo; str := "fragOffset" |},
+                                   (TypBit 13%N) );
+                                 ( {| stags := NoInfo; str := "ttl" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "protocol" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "hdrChecksum" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 32%N) );
+                                 ( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 32%N) )]) Directionless)
+                          {| stags := NoInfo; str := "protocol" |})
+                     (TypBit 8%N) Directionless)]
+               [(MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 0;
+                                     width_signed := (Some ( 13%N, false )) |})
+                                 (TypBit 13%N) Directionless) (MkExpression
+                                                                   NoInfo
+                                                                   (ExpInt
+                                                                    {| 
+                                                                    itags := NoInfo;
+                                                                    value := 0;
+                                                                    width_signed := (
+                                                                    Some
+                                                                    ( 
+                                                                    13%N,
+                                                                    false )) |})
+                                                                   (TypBit
+                                                                    13%N)
+                                                                   Directionless))
+                           (TypBit 13%N));
+                      (MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 5;
+                                     width_signed := (Some ( 4%N, false )) |})
+                                 (TypBit 4%N) Directionless) (MkExpression
+                                                                  NoInfo
+                                                                  (ExpInt
+                                                                   {| 
+                                                                   itags := NoInfo;
+                                                                   value := 15;
+                                                                   width_signed := (
+                                                                   Some
+                                                                   ( 
+                                                                   4%N,
+                                                                   false )) |})
+                                                                  (TypBit
+                                                                   4%N)
+                                                                  Directionless))
+                           (TypBit 4%N));
+                      (MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 1;
+                                     width_signed := (Some ( 8%N, false )) |})
+                                 (TypBit 8%N) Directionless) (MkExpression
+                                                                  NoInfo
+                                                                  (ExpInt
+                                                                   {| 
+                                                                   itags := NoInfo;
+                                                                   value := 255;
+                                                                   width_signed := (
+                                                                   Some
+                                                                   ( 
+                                                                   8%N,
+                                                                   false )) |})
+                                                                  (TypBit
+                                                                   8%N)
+                                                                  Directionless))
+                           (TypBit 8%N))]
+                     {| stags := NoInfo; str := "parse_icmp" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 0;
+                                     width_signed := (Some ( 13%N, false )) |})
+                                 (TypBit 13%N) Directionless) (MkExpression
+                                                                   NoInfo
+                                                                   (ExpInt
+                                                                    {| 
+                                                                    itags := NoInfo;
+                                                                    value := 0;
+                                                                    width_signed := (
+                                                                    Some
+                                                                    ( 
+                                                                    13%N,
+                                                                    false )) |})
+                                                                   (TypBit
+                                                                    13%N)
+                                                                   Directionless))
+                           (TypBit 13%N));
+                      (MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 5;
+                                     width_signed := (Some ( 4%N, false )) |})
+                                 (TypBit 4%N) Directionless) (MkExpression
+                                                                  NoInfo
+                                                                  (ExpInt
+                                                                   {| 
+                                                                   itags := NoInfo;
+                                                                   value := 15;
+                                                                   width_signed := (
+                                                                   Some
+                                                                   ( 
+                                                                   4%N,
+                                                                   false )) |})
+                                                                  (TypBit
+                                                                   4%N)
+                                                                  Directionless))
+                           (TypBit 4%N));
+                      (MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 6;
+                                     width_signed := (Some ( 8%N, false )) |})
+                                 (TypBit 8%N) Directionless) (MkExpression
+                                                                  NoInfo
+                                                                  (ExpInt
+                                                                   {| 
+                                                                   itags := NoInfo;
+                                                                   value := 255;
+                                                                   width_signed := (
+                                                                   Some
+                                                                   ( 
+                                                                   8%N,
+                                                                   false )) |})
+                                                                  (TypBit
+                                                                   8%N)
+                                                                  Directionless))
+                           (TypBit 8%N))]
+                     {| stags := NoInfo; str := "parse_tcp" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 0;
+                                     width_signed := (Some ( 13%N, false )) |})
+                                 (TypBit 13%N) Directionless) (MkExpression
+                                                                   NoInfo
+                                                                   (ExpInt
+                                                                    {| 
+                                                                    itags := NoInfo;
+                                                                    value := 0;
+                                                                    width_signed := (
+                                                                    Some
+                                                                    ( 
+                                                                    13%N,
+                                                                    false )) |})
+                                                                   (TypBit
+                                                                    13%N)
+                                                                   Directionless))
+                           (TypBit 13%N));
+                      (MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 5;
+                                     width_signed := (Some ( 4%N, false )) |})
+                                 (TypBit 4%N) Directionless) (MkExpression
+                                                                  NoInfo
+                                                                  (ExpInt
+                                                                   {| 
+                                                                   itags := NoInfo;
+                                                                   value := 15;
+                                                                   width_signed := (
+                                                                   Some
+                                                                   ( 
+                                                                   4%N,
+                                                                   false )) |})
+                                                                  (TypBit
+                                                                   4%N)
+                                                                  Directionless))
+                           (TypBit 4%N));
+                      (MkMatch NoInfo
+                           (MatchMask
+                            (MkExpression NoInfo
+                                 (ExpInt
+                                  {| itags := NoInfo; value := 17;
+                                     width_signed := (Some ( 8%N, false )) |})
+                                 (TypBit 8%N) Directionless) (MkExpression
+                                                                  NoInfo
+                                                                  (ExpInt
+                                                                   {| 
+                                                                   itags := NoInfo;
+                                                                   value := 255;
+                                                                   width_signed := (
+                                                                   Some
+                                                                   ( 
+                                                                   8%N,
+                                                                   false )) |})
+                                                                  (TypBit
+                                                                   8%N)
+                                                                  Directionless))
+                           (TypBit 8%N))]
+                     {| stags := NoInfo; str := "parse_udp" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo MatchDontCare
+                           (TypList
+                            [(TypBit 13%N); (TypBit 4%N); (TypBit 8%N)]))]
+                     {| stags := NoInfo; str := "accept" |})]));
+     (MkParserState NoInfo {| stags := NoInfo; str := "parse_ipv6" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "version" |},
+                          (TypBit 4%N) );
+                        ( {| stags := NoInfo; str := "trafficClass" |},
+                          (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "flowLabel" |},
+                          (TypBit 20%N) );
+                        ( {| stags := NoInfo; str := "payloadLen" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "nextHdr" |},
+                          (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "hopLimit" |},
+                          (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "srcAddr" |},
+                          (TypBit 128%N) );
+                        ( {| stags := NoInfo; str := "dstAddr" |},
+                          (TypBit 128%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "ipv6" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "version" |},
+                                (TypBit 4%N) );
+                              ( {| stags := NoInfo; str := "trafficClass" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "flowLabel" |},
+                                (TypBit 20%N) );
+                              ( {| stags := NoInfo; str := "payloadLen" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "nextHdr" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "hopLimit" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "srcAddr" |},
+                                (TypBit 128%N) );
+                              ( {| stags := NoInfo; str := "dstAddr" |},
+                                (TypBit 128%N) )]) Directionless))]) StmUnit)]
+          (ParserSelect NoInfo
+               [(MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) Out)
+                                    {| stags := NoInfo; str := "ipv6" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "version" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "trafficClass" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "flowLabel" |},
+                                   (TypBit 20%N) );
+                                 ( {| stags := NoInfo; str := "payloadLen" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "nextHdr" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "hopLimit" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 128%N) );
+                                 ( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 128%N) )]) Directionless)
+                          {| stags := NoInfo; str := "nextHdr" |})
+                     (TypBit 8%N) Directionless)]
+               [(MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 8%N)) (MkExpression NoInfo
+                                                       (ExpInt
+                                                        {| itags := NoInfo;
+                                                           value := 1;
+                                                           width_signed := (
+                                                           Some
+                                                           ( 8%N, false )) |})
+                                                       (TypBit 8%N)
+                                                       Directionless))
+                           (TypBit 8%N))]
+                     {| stags := NoInfo; str := "parse_icmp" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 8%N)) (MkExpression NoInfo
+                                                       (ExpInt
+                                                        {| itags := NoInfo;
+                                                           value := 6;
+                                                           width_signed := (
+                                                           Some
+                                                           ( 8%N, false )) |})
+                                                       (TypBit 8%N)
+                                                       Directionless))
+                           (TypBit 8%N))]
+                     {| stags := NoInfo; str := "parse_tcp" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 8%N)) (MkExpression NoInfo
+                                                       (ExpInt
+                                                        {| itags := NoInfo;
+                                                           value := 17;
+                                                           width_signed := (
+                                                           Some
+                                                           ( 8%N, false )) |})
+                                                       (TypBit 8%N)
+                                                       Directionless))
+                           (TypBit 8%N))]
+                     {| stags := NoInfo; str := "parse_udp" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo MatchDontCare (TypBit 8%N))]
+                     {| stags := NoInfo; str := "accept" |})]));
+     (MkParserState NoInfo {| stags := NoInfo; str := "parse_tcp" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "srcPort" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "dstPort" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "seqNo" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "ackNo" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "dataOffset" |},
+                          (TypBit 4%N) );
+                        ( {| stags := NoInfo; str := "res" |}, (TypBit 4%N) );
+                        ( {| stags := NoInfo; str := "flags" |},
+                          (TypBit 8%N) );
+                        ( {| stags := NoInfo; str := "window" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "checksum" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "urgentPtr" |},
+                          (TypBit 16%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "tcp" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "srcPort" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "dstPort" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "seqNo" |},
+                                (TypBit 32%N) );
+                              ( {| stags := NoInfo; str := "ackNo" |},
+                                (TypBit 32%N) );
+                              ( {| stags := NoInfo; str := "dataOffset" |},
+                                (TypBit 4%N) );
+                              ( {| stags := NoInfo; str := "res" |},
+                                (TypBit 4%N) );
+                              ( {| stags := NoInfo; str := "flags" |},
+                                (TypBit 8%N) );
+                              ( {| stags := NoInfo; str := "window" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "checksum" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "urgentPtr" |},
+                                (TypBit 16%N) )]) Directionless))]) StmUnit)]
+          (ParserDirect NoInfo {| stags := NoInfo; str := "accept" |}));
+     (MkParserState NoInfo {| stags := NoInfo; str := "parse_udp" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "srcPort" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "dstPort" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "length_" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "checksum" |},
+                          (TypBit 16%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "udp" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "srcPort" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "dstPort" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "length_" |},
+                                (TypBit 16%N) );
+                              ( {| stags := NoInfo; str := "checksum" |},
+                                (TypBit 16%N) )]) Directionless))]) StmUnit)]
+          (ParserDirect NoInfo {| stags := NoInfo; str := "accept" |}));
+     (MkParserState NoInfo {| stags := NoInfo; str := "parse_vlan_tag" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "pcp" |}, (TypBit 3%N) );
+                        ( {| stags := NoInfo; str := "cfi" |}, (TypBit 1%N) );
+                        ( {| stags := NoInfo; str := "vid" |},
+                          (TypBit 12%N) );
+                        ( {| stags := NoInfo; str := "etherType" |},
+                          (TypBit 16%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "vlan_tag" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "pcp" |},
+                                (TypBit 3%N) );
+                              ( {| stags := NoInfo; str := "cfi" |},
+                                (TypBit 1%N) );
+                              ( {| stags := NoInfo; str := "vid" |},
+                                (TypBit 12%N) );
+                              ( {| stags := NoInfo; str := "etherType" |},
+                                (TypBit 16%N) )]) Directionless))]) StmUnit)]
+          (ParserSelect NoInfo
+               [(MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) Out)
+                                    {| stags := NoInfo; str := "vlan_tag" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "pcp" |},
+                                   (TypBit 3%N) );
+                                 ( {| stags := NoInfo; str := "cfi" |},
+                                   (TypBit 1%N) );
+                                 ( {| stags := NoInfo; str := "vid" |},
+                                   (TypBit 12%N) );
+                                 ( {| stags := NoInfo; str := "etherType" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "etherType" |})
+                     (TypBit 16%N) Directionless)]
+               [(MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 16%N)) (MkExpression NoInfo
+                                                        (ExpInt
+                                                         {| itags := NoInfo;
+                                                            value := 2048;
+                                                            width_signed := (
+                                                            Some
+                                                            ( 16%N, false )) |})
+                                                        (TypBit 16%N)
+                                                        Directionless))
+                           (TypBit 16%N))]
+                     {| stags := NoInfo; str := "parse_ipv4" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 16%N)) (MkExpression NoInfo
+                                                        (ExpInt
+                                                         {| itags := NoInfo;
+                                                            value := 34525;
+                                                            width_signed := (
+                                                            Some
+                                                            ( 16%N, false )) |})
+                                                        (TypBit 16%N)
+                                                        Directionless))
+                           (TypBit 16%N))]
+                     {| stags := NoInfo; str := "parse_ipv6" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo MatchDontCare (TypBit 16%N))]
+                     {| stags := NoInfo; str := "accept" |})]));
+     (MkParserState NoInfo {| stags := NoInfo; str := "start" |}
+          [(MkStatement NoInfo
+                (StatMethodCall
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "packet" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo;
+                                         str := "packet_in" |}))
+                                    Directionless)
+                               {| stags := NoInfo; str := "extract" |})
+                          (TypFunction
+                           (MkFunctionType
+                                [{| stags := NoInfo; str := "T" |}]
+                                [(MkParameter false Out
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo; str := "T" |}))
+                                      None
+                                      {| stags := NoInfo; str := "hdr" |})]
+                                FunExtern TypVoid)) Directionless)
+                     [(TypHeader
+                       [( {| stags := NoInfo; str := "dstAddr" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo; str := "srcAddr" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo; str := "etherType" |},
+                          (TypBit 16%N) )])]
+                     [(Some
+                       (MkExpression NoInfo
+                            (ExpExpressionMember
+                                 (MkExpression NoInfo
+                                      (ExpName
+                                       (BareName
+                                        {| stags := NoInfo; str := "hdr" |})
+                                       NoLocator)
+                                      (TypTypeName
+                                       (BareName
+                                        {| stags := NoInfo;
+                                           str := "headers" |})) Out)
+                                 {| stags := NoInfo; str := "ethernet" |})
+                            (TypHeader
+                             [( {| stags := NoInfo; str := "dstAddr" |},
+                                (TypBit 48%N) );
+                              ( {| stags := NoInfo; str := "srcAddr" |},
+                                (TypBit 48%N) );
+                              ( {| stags := NoInfo; str := "etherType" |},
+                                (TypBit 16%N) )]) Directionless))]) StmUnit)]
+          (ParserSelect NoInfo
+               [(MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) Out)
+                                    {| stags := NoInfo; str := "ethernet" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 48%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 48%N) );
+                                 ( {| stags := NoInfo; str := "etherType" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "etherType" |})
+                     (TypBit 16%N) Directionless)]
+               [(MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 16%N)) (MkExpression NoInfo
+                                                        (ExpInt
+                                                         {| itags := NoInfo;
+                                                            value := 33024;
+                                                            width_signed := (
+                                                            Some
+                                                            ( 16%N, false )) |})
+                                                        (TypBit 16%N)
+                                                        Directionless))
+                           (TypBit 16%N))]
+                     {| stags := NoInfo; str := "parse_vlan_tag" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 16%N)) (MkExpression NoInfo
+                                                        (ExpInt
+                                                         {| itags := NoInfo;
+                                                            value := 37120;
+                                                            width_signed := (
+                                                            Some
+                                                            ( 16%N, false )) |})
+                                                        (TypBit 16%N)
+                                                        Directionless))
+                           (TypBit 16%N))]
+                     {| stags := NoInfo; str := "parse_vlan_tag" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 16%N)) (MkExpression NoInfo
+                                                        (ExpInt
+                                                         {| itags := NoInfo;
+                                                            value := 2048;
+                                                            width_signed := (
+                                                            Some
+                                                            ( 16%N, false )) |})
+                                                        (TypBit 16%N)
+                                                        Directionless))
+                           (TypBit 16%N))]
+                     {| stags := NoInfo; str := "parse_ipv4" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo
+                           (MatchCast
+                            (TypSet (TypBit 16%N)) (MkExpression NoInfo
+                                                        (ExpInt
+                                                         {| itags := NoInfo;
+                                                            value := 34525;
+                                                            width_signed := (
+                                                            Some
+                                                            ( 16%N, false )) |})
+                                                        (TypBit 16%N)
+                                                        Directionless))
+                           (TypBit 16%N))]
+                     {| stags := NoInfo; str := "parse_ipv6" |});
+                (MkParserCase NoInfo
+                     [(MkMatch NoInfo MatchDontCare (TypBit 16%N))]
+                     {| stags := NoInfo; str := "accept" |})]))].
+
+Definition egress := DeclControl NoInfo
+    {| stags := NoInfo; str := "egress" |} nil
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          None {| stags := NoInfo; str := "meta" |});
+     (MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})] nil nil
+    (BlockEmpty NoInfo).
+
+Definition ingress := DeclControl NoInfo
+    {| stags := NoInfo; str := "ingress" |} nil
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          None {| stags := NoInfo; str := "meta" |});
+     (MkParameter false InOut
+          (TypTypeName
+           (BareName {| stags := NoInfo; str := "standard_metadata_t" |}))
+          None {| stags := NoInfo; str := "standard_metadata" |})] nil
+    [(DeclAction NoInfo {| stags := NoInfo; str := "l2_packet" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "packet_type" |}) (TypBit 4%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpInt
+                               {| itags := NoInfo; value := 0;
+                                  width_signed := (Some ( 4%N, false )) |})
+                              (TypBit 4%N) Directionless)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "ipv4_packet" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "packet_type" |}) (TypBit 4%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpInt
+                               {| itags := NoInfo; value := 1;
+                                  width_signed := (Some ( 4%N, false )) |})
+                              (TypBit 4%N) Directionless)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "ipv6_packet" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "packet_type" |}) (TypBit 4%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpInt
+                               {| itags := NoInfo; value := 2;
+                                  width_signed := (Some ( 4%N, false )) |})
+                              (TypBit 4%N) Directionless)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "mpls_packet" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "packet_type" |}) (TypBit 4%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpInt
+                               {| itags := NoInfo; value := 3;
+                                  width_signed := (Some ( 4%N, false )) |})
+                              (TypBit 4%N) Directionless)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "mim_packet" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "packet_type" |}) (TypBit 4%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpInt
+                               {| itags := NoInfo; value := 4;
+                                  width_signed := (Some ( 4%N, false )) |})
+                              (TypBit 4%N) Directionless)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "nop" |} nil nil
+          (BlockEmpty NoInfo));
+     (DeclAction NoInfo {| stags := NoInfo; str := "_drop" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo; str := "drop" |})
+                              (TypBit 1%N) Directionless)
+                         (MkExpression NoInfo
+                              (ExpInt
+                               {| itags := NoInfo; value := 1;
+                                  width_signed := (Some ( 1%N, false )) |})
+                              (TypBit 1%N) Directionless)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "set_egress_port" |} nil
+          [(MkParameter false Directionless (TypBit 9%N) None
+                {| stags := NoInfo; str := "egress_port" |})]
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "egress_port" |}) (TypBit 9%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpName
+                               (BareName
+                                {| stags := NoInfo; str := "egress_port" |})
+                               NoLocator) (TypBit 9%N) In)) StmUnit)
+               (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "discard" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatMethodCall
+                         (MkExpression NoInfo
+                              (ExpName
+                               (BareName
+                                {| stags := NoInfo; str := "mark_to_drop" |})
+                               NoLocator)
+                              (TypFunction
+                               (MkFunctionType nil
+                                    [(MkParameter false InOut
+                                          (TypTypeName
+                                           (BareName
+                                            {| stags := NoInfo;
+                                               str := "standard_metadata_t" |}))
+                                          None
+                                          {| stags := NoInfo;
+                                             str := "standard_metadata" |})]
+                                    FunExtern TypVoid)) Directionless) nil
+                         [(Some
+                           (MkExpression NoInfo
+                                (ExpName
+                                 (BareName
+                                  {| stags := NoInfo;
+                                     str := "standard_metadata" |})
+                                 NoLocator)
+                                (TypTypeName
+                                 (BareName
+                                  {| stags := NoInfo;
+                                     str := "standard_metadata_t" |})) InOut))])
+                    StmUnit) (BlockEmpty NoInfo)));
+     (DeclAction NoInfo {| stags := NoInfo; str := "send_packet" |} nil nil
+          (BlockCons
+               (MkStatement NoInfo
+                    (StatAssignment
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpName
+                                         (BareName
+                                          {| stags := NoInfo;
+                                             str := "standard_metadata" |})
+                                         NoLocator)
+                                        (TypTypeName
+                                         (BareName
+                                          {| stags := NoInfo;
+                                             str := "standard_metadata_t" |}))
+                                        InOut)
+                                   {| stags := NoInfo;
+                                      str := "egress_spec" |}) (TypBit 9%N)
+                              Directionless)
+                         (MkExpression NoInfo
+                              (ExpExpressionMember
+                                   (MkExpression NoInfo
+                                        (ExpExpressionMember
+                                             (MkExpression NoInfo
+                                                  (ExpName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "meta" |})
+                                                   NoLocator)
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "metadata" |}))
+                                                  InOut)
+                                             {| stags := NoInfo;
+                                                str := "ing_metadata" |})
+                                        (TypStruct
+                                         [( {| stags := NoInfo;
+                                               str := "drop" |},
+                                            (TypBit 1%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "egress_port" |},
+                                            (TypBit 9%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "packet_type" |},
+                                            (TypBit 4%N) )]) Directionless)
+                                   {| stags := NoInfo;
+                                      str := "egress_port" |}) (TypBit 9%N)
+                              Directionless)) StmUnit) (BlockEmpty NoInfo)));
+     (DeclTable NoInfo {| stags := NoInfo; str := "ethertype_match" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "ethernet" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 48%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 48%N) );
+                                 ( {| stags := NoInfo; str := "etherType" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "etherType" |})
+                     (TypBit 16%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "l2_packet" |})
+                     nil) (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "ipv4_packet" |})
+                     nil) (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "ipv6_packet" |})
+                     nil) (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "mpls_packet" |})
+                     nil) (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "mim_packet" |})
+                     nil) (TypAction nil nil))] None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "icmp_check" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "icmp" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "typeCode" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "hdrChecksum" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "typeCode" |})
+                     (TypBit 16%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "nop" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "_drop" |}) nil)
+                (TypAction nil nil))] None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "ipv4_match" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "ipv4" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "version" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "ihl" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "diffserv" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "totalLen" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "identification" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "flags" |},
+                                   (TypBit 3%N) );
+                                 ( {| stags := NoInfo; str := "fragOffset" |},
+                                   (TypBit 13%N) );
+                                 ( {| stags := NoInfo; str := "ttl" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "protocol" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "hdrChecksum" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 32%N) );
+                                 ( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 32%N) )]) Directionless)
+                          {| stags := NoInfo; str := "dstAddr" |})
+                     (TypBit 32%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "nop" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName
+                      {| stags := NoInfo; str := "set_egress_port" |}) nil)
+                (TypAction nil
+                     [(MkParameter false Directionless (TypBit 9%N) None
+                           {| stags := NoInfo; str := "egress_port" |})]))]
+          None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "ipv6_match" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "ipv6" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "version" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "trafficClass" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "flowLabel" |},
+                                   (TypBit 20%N) );
+                                 ( {| stags := NoInfo; str := "payloadLen" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "nextHdr" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "hopLimit" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 128%N) );
+                                 ( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 128%N) )]) Directionless)
+                          {| stags := NoInfo; str := "dstAddr" |})
+                     (TypBit 128%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "nop" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName
+                      {| stags := NoInfo; str := "set_egress_port" |}) nil)
+                (TypAction nil
+                     [(MkParameter false Directionless (TypBit 9%N) None
+                           {| stags := NoInfo; str := "egress_port" |})]))]
+          None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "l2_match" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "ethernet" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "dstAddr" |},
+                                   (TypBit 48%N) );
+                                 ( {| stags := NoInfo; str := "srcAddr" |},
+                                   (TypBit 48%N) );
+                                 ( {| stags := NoInfo; str := "etherType" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "dstAddr" |})
+                     (TypBit 48%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "nop" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName
+                      {| stags := NoInfo; str := "set_egress_port" |}) nil)
+                (TypAction nil
+                     [(MkParameter false Directionless (TypBit 9%N) None
+                           {| stags := NoInfo; str := "egress_port" |})]))]
+          None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "set_egress" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "meta" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "metadata" |})) InOut)
+                                    {| stags := NoInfo;
+                                       str := "ing_metadata" |})
+                               (TypStruct
+                                [( {| stags := NoInfo; str := "drop" |},
+                                   (TypBit 1%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "egress_port" |}, (TypBit 9%N) );
+                                 ( {| stags := NoInfo;
+                                      str := "packet_type" |}, (TypBit 4%N) )])
+                               Directionless)
+                          {| stags := NoInfo; str := "drop" |}) (TypBit 1%N)
+                     Directionless) {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "discard" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "send_packet" |})
+                     nil) (TypAction nil nil))] None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "tcp_check" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "tcp" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "srcPort" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "dstPort" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "seqNo" |},
+                                   (TypBit 32%N) );
+                                 ( {| stags := NoInfo; str := "ackNo" |},
+                                   (TypBit 32%N) );
+                                 ( {| stags := NoInfo; str := "dataOffset" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "res" |},
+                                   (TypBit 4%N) );
+                                 ( {| stags := NoInfo; str := "flags" |},
+                                   (TypBit 8%N) );
+                                 ( {| stags := NoInfo; str := "window" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "checksum" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "urgentPtr" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "dstPort" |})
+                     (TypBit 16%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "nop" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "_drop" |}) nil)
+                (TypAction nil nil))] None None None nil);
+     (DeclTable NoInfo {| stags := NoInfo; str := "udp_check" |}
+          [(MkTableKey NoInfo
+                (MkExpression NoInfo
+                     (ExpExpressionMember
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) InOut)
+                                    {| stags := NoInfo; str := "udp" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "srcPort" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "dstPort" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "length_" |},
+                                   (TypBit 16%N) );
+                                 ( {| stags := NoInfo; str := "checksum" |},
+                                   (TypBit 16%N) )]) Directionless)
+                          {| stags := NoInfo; str := "dstPort" |})
+                     (TypBit 16%N) Directionless)
+                {| stags := NoInfo; str := "exact" |})]
+          [(MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "nop" |}) nil)
+                (TypAction nil nil));
+           (MkTableActionRef NoInfo
+                (MkTablePreActionRef
+                     (BareName {| stags := NoInfo; str := "_drop" |}) nil)
+                (TypAction nil nil))] None None None nil)]
+    (BlockCons
+         (MkStatement NoInfo
+              (StatSwitch
+                   (MkExpression NoInfo
+                        (ExpExpressionMember
+                             (MkExpression NoInfo
+                                  (ExpFunctionCall
+                                       (MkExpression NoInfo
+                                            (ExpExpressionMember
+                                                 (MkExpression NoInfo
+                                                      (ExpName
+                                                       (BareName
+                                                        {| stags := NoInfo;
+                                                           str := "ethertype_match" |})
+                                                       NoLocator)
+                                                      (TypTable
+                                                       {| stags := NoInfo;
+                                                          str := "apply_result_ethertype_match" |})
+                                                      Directionless)
+                                                 {| stags := NoInfo;
+                                                    str := "apply" |})
+                                            (TypFunction
+                                             (MkFunctionType nil nil FunTable
+                                                  (TypTypeName
+                                                   (BareName
+                                                    {| stags := NoInfo;
+                                                       str := "apply_result_ethertype_match" |}))))
+                                            Directionless) nil nil)
+                                  (TypStruct
+                                   [( {| stags := NoInfo; str := "hit" |},
+                                      TypBool );
+                                    ( {| stags := NoInfo; str := "miss" |},
+                                      TypBool );
+                                    ( {| stags := NoInfo;
+                                         str := "action_run" |},
+                                      (TypEnum
+                                           {| stags := NoInfo;
+                                              str := "action_list_ethertype_match" |}
+                                           None
+                                           [{| stags := NoInfo;
+                                               str := "l2_packet" |};
+                                            {| stags := NoInfo;
+                                               str := "ipv4_packet" |};
+                                            {| stags := NoInfo;
+                                               str := "ipv6_packet" |};
+                                            {| stags := NoInfo;
+                                               str := "mpls_packet" |};
+                                            {| stags := NoInfo;
+                                               str := "mim_packet" |}]) )])
+                                  Directionless)
+                             {| stags := NoInfo; str := "action_run" |})
+                        (TypEnum
+                             {| stags := NoInfo;
+                                str := "action_list_ethertype_match" |} 
+                             None
+                             [{| stags := NoInfo; str := "l2_packet" |};
+                              {| stags := NoInfo; str := "ipv4_packet" |};
+                              {| stags := NoInfo; str := "ipv6_packet" |};
+                              {| stags := NoInfo; str := "mpls_packet" |};
+                              {| stags := NoInfo; str := "mim_packet" |}])
+                        Directionless)
+                   [(StatSwCaseAction NoInfo
+                         (StatSwLabName NoInfo
+                              {| stags := NoInfo; str := "ipv4_packet" |})
+                         (BlockCons
+                              (MkStatement NoInfo
+                                   (StatMethodCall
+                                        (MkExpression NoInfo
+                                             (ExpExpressionMember
+                                                  (MkExpression NoInfo
+                                                       (ExpName
+                                                        (BareName
+                                                         {| stags := NoInfo;
+                                                            str := "ipv4_match" |})
+                                                        NoLocator)
+                                                       (TypTable
+                                                        {| stags := NoInfo;
+                                                           str := "apply_result_ipv4_match" |})
+                                                       Directionless)
+                                                  {| stags := NoInfo;
+                                                     str := "apply" |})
+                                             (TypFunction
+                                              (MkFunctionType nil nil
+                                                   FunTable
+                                                   (TypTypeName
+                                                    (BareName
+                                                     {| stags := NoInfo;
+                                                        str := "apply_result_ipv4_match" |}))))
+                                             Directionless) nil nil) StmUnit)
+                              (BlockEmpty NoInfo)));
+                    (StatSwCaseFallThrough NoInfo
+                         (StatSwLabName NoInfo
+                              {| stags := NoInfo; str := "mpls_packet" |}));
+                    (StatSwCaseAction NoInfo
+                         (StatSwLabName NoInfo
+                              {| stags := NoInfo; str := "ipv6_packet" |})
+                         (BlockCons
+                              (MkStatement NoInfo
+                                   (StatMethodCall
+                                        (MkExpression NoInfo
+                                             (ExpExpressionMember
+                                                  (MkExpression NoInfo
+                                                       (ExpName
+                                                        (BareName
+                                                         {| stags := NoInfo;
+                                                            str := "ipv6_match" |})
+                                                        NoLocator)
+                                                       (TypTable
+                                                        {| stags := NoInfo;
+                                                           str := "apply_result_ipv6_match" |})
+                                                       Directionless)
+                                                  {| stags := NoInfo;
+                                                     str := "apply" |})
+                                             (TypFunction
+                                              (MkFunctionType nil nil
+                                                   FunTable
+                                                   (TypTypeName
+                                                    (BareName
+                                                     {| stags := NoInfo;
+                                                        str := "apply_result_ipv6_match" |}))))
+                                             Directionless) nil nil) StmUnit)
+                              (BlockEmpty NoInfo)));
+                    (StatSwCaseAction NoInfo (StatSwLabDefault NoInfo)
+                         (BlockCons
+                              (MkStatement NoInfo
+                                   (StatMethodCall
+                                        (MkExpression NoInfo
+                                             (ExpExpressionMember
+                                                  (MkExpression NoInfo
+                                                       (ExpName
+                                                        (BareName
+                                                         {| stags := NoInfo;
+                                                            str := "l2_match" |})
+                                                        NoLocator)
+                                                       (TypTable
+                                                        {| stags := NoInfo;
+                                                           str := "apply_result_l2_match" |})
+                                                       Directionless)
+                                                  {| stags := NoInfo;
+                                                     str := "apply" |})
+                                             (TypFunction
+                                              (MkFunctionType nil nil
+                                                   FunTable
+                                                   (TypTypeName
+                                                    (BareName
+                                                     {| stags := NoInfo;
+                                                        str := "apply_result_l2_match" |}))))
+                                             Directionless) nil nil) StmUnit)
+                              (BlockEmpty NoInfo)))]) StmUnit)
+         (BlockCons
+              (MkStatement NoInfo
+                   (StatConditional
+                        (MkExpression NoInfo
+                             (ExpFunctionCall
+                                  (MkExpression NoInfo
+                                       (ExpExpressionMember
+                                            (MkExpression NoInfo
+                                                 (ExpExpressionMember
+                                                      (MkExpression NoInfo
+                                                           (ExpName
+                                                            (BareName
+                                                             {| stags := NoInfo;
+                                                                str := "hdr" |})
+                                                            NoLocator)
+                                                           (TypTypeName
+                                                            (BareName
+                                                             {| stags := NoInfo;
+                                                                str := "headers" |}))
+                                                           InOut)
+                                                      {| stags := NoInfo;
+                                                         str := "tcp" |})
+                                                 (TypHeader
+                                                  [( {| stags := NoInfo;
+                                                        str := "srcPort" |},
+                                                     (TypBit 16%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "dstPort" |},
+                                                     (TypBit 16%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "seqNo" |},
+                                                     (TypBit 32%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "ackNo" |},
+                                                     (TypBit 32%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "dataOffset" |},
+                                                     (TypBit 4%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "res" |},
+                                                     (TypBit 4%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "flags" |},
+                                                     (TypBit 8%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "window" |},
+                                                     (TypBit 16%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "checksum" |},
+                                                     (TypBit 16%N) );
+                                                   ( {| stags := NoInfo;
+                                                        str := "urgentPtr" |},
+                                                     (TypBit 16%N) )])
+                                                 Directionless)
+                                            {| stags := NoInfo;
+                                               str := "isValid" |})
+                                       (TypFunction
+                                        (MkFunctionType nil nil FunBuiltin
+                                             TypBool)) Directionless) nil
+                                  nil) TypBool Directionless)
+                        (MkStatement NoInfo
+                             (StatBlock
+                              (BlockCons
+                                   (MkStatement NoInfo
+                                        (StatMethodCall
+                                             (MkExpression NoInfo
+                                                  (ExpExpressionMember
+                                                       (MkExpression NoInfo
+                                                            (ExpName
+                                                             (BareName
+                                                              {| stags := NoInfo;
+                                                                 str := "tcp_check" |})
+                                                             NoLocator)
+                                                            (TypTable
+                                                             {| stags := NoInfo;
+                                                                str := "apply_result_tcp_check" |})
+                                                            Directionless)
+                                                       {| stags := NoInfo;
+                                                          str := "apply" |})
+                                                  (TypFunction
+                                                   (MkFunctionType nil nil
+                                                        FunTable
+                                                        (TypTypeName
+                                                         (BareName
+                                                          {| stags := NoInfo;
+                                                             str := "apply_result_tcp_check" |}))))
+                                                  Directionless) nil nil)
+                                        StmUnit) (BlockEmpty NoInfo)))
+                             StmUnit)
+                        (Some
+                         (MkStatement NoInfo
+                              (StatBlock
+                               (BlockCons
+                                    (MkStatement NoInfo
+                                         (StatConditional
+                                              (MkExpression NoInfo
+                                                   (ExpFunctionCall
+                                                        (MkExpression NoInfo
+                                                             (ExpExpressionMember
+                                                                  (MkExpression
+                                                                    NoInfo
+                                                                    (ExpExpressionMember
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "hdr" |})
+                                                                    NoLocator)
+                                                                    (TypTypeName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "headers" |}))
+                                                                    InOut)
+                                                                    {| stags := NoInfo;
+                                                                    str := "udp" |})
+                                                                    (TypHeader
+                                                                    [( 
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "srcPort" |},
+                                                                    (
+                                                                    TypBit
+                                                                    16%N) );
+                                                                    ( 
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "dstPort" |},
+                                                                    (
+                                                                    TypBit
+                                                                    16%N) );
+                                                                    ( 
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "length_" |},
+                                                                    (
+                                                                    TypBit
+                                                                    16%N) );
+                                                                    ( 
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "checksum" |},
+                                                                    (
+                                                                    TypBit
+                                                                    16%N) )])
+                                                                    Directionless)
+                                                                  {| 
+                                                                  stags := NoInfo;
+                                                                  str := "isValid" |})
+                                                             (TypFunction
+                                                              (MkFunctionType
+                                                                   nil nil
+                                                                   FunBuiltin
+                                                                   TypBool))
+                                                             Directionless)
+                                                        nil nil) TypBool
+                                                   Directionless)
+                                              (MkStatement NoInfo
+                                                   (StatBlock
+                                                    (BlockCons
+                                                         (MkStatement NoInfo
+                                                              (StatMethodCall
+                                                                   (MkExpression
+                                                                    NoInfo
+                                                                    (ExpExpressionMember
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "udp_check" |})
+                                                                    NoLocator)
+                                                                    (TypTable
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "apply_result_udp_check" |})
+                                                                    Directionless)
+                                                                    {| stags := NoInfo;
+                                                                    str := "apply" |})
+                                                                    (TypFunction
+                                                                    (MkFunctionType
+                                                                    nil nil
+                                                                    FunTable
+                                                                    (TypTypeName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "apply_result_udp_check" |}))))
+                                                                    Directionless)
+                                                                   nil nil)
+                                                              StmUnit)
+                                                         (BlockEmpty NoInfo)))
+                                                   StmUnit)
+                                              (Some
+                                               (MkStatement NoInfo
+                                                    (StatBlock
+                                                     (BlockCons
+                                                          (MkStatement NoInfo
+                                                               (StatConditional
+                                                                    (
+                                                                    MkExpression
+                                                                    NoInfo
+                                                                    (ExpFunctionCall
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpExpressionMember
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpExpressionMember
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "hdr" |})
+                                                                    NoLocator)
+                                                                    (TypTypeName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "headers" |}))
+                                                                    InOut)
+                                                                    {| stags := NoInfo;
+                                                                    str := "icmp" |})
+                                                                    (TypHeader
+                                                                    [( 
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "typeCode" |},
+                                                                    (
+                                                                    TypBit
+                                                                    16%N) );
+                                                                    ( 
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "hdrChecksum" |},
+                                                                    (
+                                                                    TypBit
+                                                                    16%N) )])
+                                                                    Directionless)
+                                                                    {| stags := NoInfo;
+                                                                    str := "isValid" |})
+                                                                    (TypFunction
+                                                                    (MkFunctionType
+                                                                    nil nil
+                                                                    FunBuiltin
+                                                                    TypBool))
+                                                                    Directionless)
+                                                                    nil nil)
+                                                                    TypBool
+                                                                    Directionless)
+                                                                    (
+                                                                    MkStatement
+                                                                    NoInfo
+                                                                    (StatBlock
+                                                                    (BlockCons
+                                                                    (MkStatement
+                                                                    NoInfo
+                                                                    (StatMethodCall
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpExpressionMember
+                                                                    (MkExpression
+                                                                    NoInfo
+                                                                    (ExpName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "icmp_check" |})
+                                                                    NoLocator)
+                                                                    (TypTable
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "apply_result_icmp_check" |})
+                                                                    Directionless)
+                                                                    {| stags := NoInfo;
+                                                                    str := "apply" |})
+                                                                    (TypFunction
+                                                                    (MkFunctionType
+                                                                    nil nil
+                                                                    FunTable
+                                                                    (TypTypeName
+                                                                    (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "apply_result_icmp_check" |}))))
+                                                                    Directionless)
+                                                                    nil nil)
+                                                                    StmUnit)
+                                                                    (BlockEmpty
+                                                                    NoInfo)))
+                                                                    StmUnit)
+                                                                    None)
+                                                               StmUnit)
+                                                          (BlockEmpty NoInfo)))
+                                                    StmUnit))) StmUnit)
+                                    (BlockEmpty NoInfo))) StmUnit))) StmUnit)
+              (BlockCons
+                   (MkStatement NoInfo
+                        (StatMethodCall
+                             (MkExpression NoInfo
+                                  (ExpExpressionMember
+                                       (MkExpression NoInfo
+                                            (ExpName
+                                             (BareName
+                                              {| stags := NoInfo;
+                                                 str := "set_egress" |})
+                                             NoLocator)
+                                            (TypTable
+                                             {| stags := NoInfo;
+                                                str := "apply_result_set_egress" |})
+                                            Directionless)
+                                       {| stags := NoInfo; str := "apply" |})
+                                  (TypFunction
+                                   (MkFunctionType nil nil FunTable
+                                        (TypTypeName
+                                         (BareName
+                                          {| stags := NoInfo;
+                                             str := "apply_result_set_egress" |}))))
+                                  Directionless) nil nil) StmUnit)
+                   (BlockEmpty NoInfo)))).
+
+Definition DeparserImpl := DeclControl NoInfo
+    {| stags := NoInfo; str := "DeparserImpl" |} nil
+    [(MkParameter false Directionless
+          (TypTypeName (BareName {| stags := NoInfo; str := "packet_out" |}))
+          None {| stags := NoInfo; str := "packet" |});
+     (MkParameter false In
+          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          None {| stags := NoInfo; str := "hdr" |})] nil nil
+    (BlockCons
+         (MkStatement NoInfo
+              (StatMethodCall
+                   (MkExpression NoInfo
+                        (ExpExpressionMember
+                             (MkExpression NoInfo
+                                  (ExpName
+                                   (BareName
+                                    {| stags := NoInfo; str := "packet" |})
+                                   NoLocator)
+                                  (TypTypeName
+                                   (BareName
+                                    {| stags := NoInfo;
+                                       str := "packet_out" |}))
+                                  Directionless)
+                             {| stags := NoInfo; str := "emit" |})
+                        (TypFunction
+                         (MkFunctionType [{| stags := NoInfo; str := "T2" |}]
+                              [(MkParameter false In
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo; str := "T2" |}))
+                                    None {| stags := NoInfo; str := "hdr" |})]
+                              FunExtern TypVoid)) Directionless)
+                   [(TypHeader
+                     [( {| stags := NoInfo; str := "dstAddr" |},
+                        (TypBit 48%N) );
+                      ( {| stags := NoInfo; str := "srcAddr" |},
+                        (TypBit 48%N) );
+                      ( {| stags := NoInfo; str := "etherType" |},
+                        (TypBit 16%N) )])]
+                   [(Some
+                     (MkExpression NoInfo
+                          (ExpExpressionMember
+                               (MkExpression NoInfo
+                                    (ExpName
+                                     (BareName
+                                      {| stags := NoInfo; str := "hdr" |})
+                                     NoLocator)
+                                    (TypTypeName
+                                     (BareName
+                                      {| stags := NoInfo; str := "headers" |}))
+                                    In)
+                               {| stags := NoInfo; str := "ethernet" |})
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) Directionless))]) StmUnit)
+         (BlockCons
+              (MkStatement NoInfo
+                   (StatMethodCall
+                        (MkExpression NoInfo
+                             (ExpExpressionMember
+                                  (MkExpression NoInfo
+                                       (ExpName
+                                        (BareName
+                                         {| stags := NoInfo;
+                                            str := "packet" |}) NoLocator)
+                                       (TypTypeName
+                                        (BareName
+                                         {| stags := NoInfo;
+                                            str := "packet_out" |}))
+                                       Directionless)
+                                  {| stags := NoInfo; str := "emit" |})
+                             (TypFunction
+                              (MkFunctionType
+                                   [{| stags := NoInfo; str := "T2" |}]
+                                   [(MkParameter false In
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo; str := "T2" |}))
+                                         None
+                                         {| stags := NoInfo; str := "hdr" |})]
+                                   FunExtern TypVoid)) Directionless)
+                        [(TypHeader
+                          [( {| stags := NoInfo; str := "pcp" |},
+                             (TypBit 3%N) );
+                           ( {| stags := NoInfo; str := "cfi" |},
+                             (TypBit 1%N) );
+                           ( {| stags := NoInfo; str := "vid" |},
+                             (TypBit 12%N) );
+                           ( {| stags := NoInfo; str := "etherType" |},
+                             (TypBit 16%N) )])]
+                        [(Some
+                          (MkExpression NoInfo
+                               (ExpExpressionMember
+                                    (MkExpression NoInfo
+                                         (ExpName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "hdr" |}) NoLocator)
+                                         (TypTypeName
+                                          (BareName
+                                           {| stags := NoInfo;
+                                              str := "headers" |})) In)
+                                    {| stags := NoInfo; str := "vlan_tag" |})
+                               (TypHeader
+                                [( {| stags := NoInfo; str := "pcp" |},
+                                   (TypBit 3%N) );
+                                 ( {| stags := NoInfo; str := "cfi" |},
+                                   (TypBit 1%N) );
+                                 ( {| stags := NoInfo; str := "vid" |},
+                                   (TypBit 12%N) );
+                                 ( {| stags := NoInfo; str := "etherType" |},
+                                   (TypBit 16%N) )]) Directionless))])
+                   StmUnit)
+              (BlockCons
+                   (MkStatement NoInfo
+                        (StatMethodCall
+                             (MkExpression NoInfo
+                                  (ExpExpressionMember
+                                       (MkExpression NoInfo
+                                            (ExpName
+                                             (BareName
+                                              {| stags := NoInfo;
+                                                 str := "packet" |})
+                                             NoLocator)
+                                            (TypTypeName
+                                             (BareName
+                                              {| stags := NoInfo;
+                                                 str := "packet_out" |}))
+                                            Directionless)
+                                       {| stags := NoInfo; str := "emit" |})
+                                  (TypFunction
+                                   (MkFunctionType
+                                        [{| stags := NoInfo; str := "T2" |}]
+                                        [(MkParameter false In
+                                              (TypTypeName
+                                               (BareName
+                                                {| stags := NoInfo;
+                                                   str := "T2" |})) None
+                                              {| stags := NoInfo;
+                                                 str := "hdr" |})] FunExtern
+                                        TypVoid)) Directionless)
+                             [(TypHeader
+                               [( {| stags := NoInfo; str := "version" |},
+                                  (TypBit 4%N) );
+                                ( {| stags := NoInfo;
+                                     str := "trafficClass" |}, (TypBit 8%N) );
+                                ( {| stags := NoInfo; str := "flowLabel" |},
+                                  (TypBit 20%N) );
+                                ( {| stags := NoInfo; str := "payloadLen" |},
+                                  (TypBit 16%N) );
+                                ( {| stags := NoInfo; str := "nextHdr" |},
+                                  (TypBit 8%N) );
+                                ( {| stags := NoInfo; str := "hopLimit" |},
+                                  (TypBit 8%N) );
+                                ( {| stags := NoInfo; str := "srcAddr" |},
+                                  (TypBit 128%N) );
+                                ( {| stags := NoInfo; str := "dstAddr" |},
+                                  (TypBit 128%N) )])]
+                             [(Some
+                               (MkExpression NoInfo
+                                    (ExpExpressionMember
+                                         (MkExpression NoInfo
+                                              (ExpName
+                                               (BareName
+                                                {| stags := NoInfo;
+                                                   str := "hdr" |})
+                                               NoLocator)
+                                              (TypTypeName
+                                               (BareName
+                                                {| stags := NoInfo;
+                                                   str := "headers" |})) In)
+                                         {| stags := NoInfo; str := "ipv6" |})
+                                    (TypHeader
+                                     [( {| stags := NoInfo;
+                                           str := "version" |},
+                                        (TypBit 4%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "trafficClass" |},
+                                        (TypBit 8%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "flowLabel" |},
+                                        (TypBit 20%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "payloadLen" |},
+                                        (TypBit 16%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "nextHdr" |},
+                                        (TypBit 8%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "hopLimit" |},
+                                        (TypBit 8%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "srcAddr" |},
+                                        (TypBit 128%N) );
+                                      ( {| stags := NoInfo;
+                                           str := "dstAddr" |},
+                                        (TypBit 128%N) )]) Directionless))])
+                        StmUnit)
+                   (BlockCons
+                        (MkStatement NoInfo
+                             (StatMethodCall
+                                  (MkExpression NoInfo
+                                       (ExpExpressionMember
+                                            (MkExpression NoInfo
+                                                 (ExpName
+                                                  (BareName
+                                                   {| stags := NoInfo;
+                                                      str := "packet" |})
+                                                  NoLocator)
+                                                 (TypTypeName
+                                                  (BareName
+                                                   {| stags := NoInfo;
+                                                      str := "packet_out" |}))
+                                                 Directionless)
+                                            {| stags := NoInfo;
+                                               str := "emit" |})
+                                       (TypFunction
+                                        (MkFunctionType
+                                             [{| stags := NoInfo;
+                                                 str := "T2" |}]
+                                             [(MkParameter false In
+                                                   (TypTypeName
+                                                    (BareName
+                                                     {| stags := NoInfo;
+                                                        str := "T2" |})) 
+                                                   None
+                                                   {| stags := NoInfo;
+                                                      str := "hdr" |})]
+                                             FunExtern TypVoid))
+                                       Directionless)
+                                  [(TypHeader
+                                    [( {| stags := NoInfo;
+                                          str := "version" |}, (TypBit 4%N) );
+                                     ( {| stags := NoInfo; str := "ihl" |},
+                                       (TypBit 4%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "diffserv" |},
+                                       (TypBit 8%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "totalLen" |},
+                                       (TypBit 16%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "identification" |},
+                                       (TypBit 16%N) );
+                                     ( {| stags := NoInfo; str := "flags" |},
+                                       (TypBit 3%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "fragOffset" |},
+                                       (TypBit 13%N) );
+                                     ( {| stags := NoInfo; str := "ttl" |},
+                                       (TypBit 8%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "protocol" |},
+                                       (TypBit 8%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "hdrChecksum" |},
+                                       (TypBit 16%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "srcAddr" |},
+                                       (TypBit 32%N) );
+                                     ( {| stags := NoInfo;
+                                          str := "dstAddr" |},
+                                       (TypBit 32%N) )])]
+                                  [(Some
+                                    (MkExpression NoInfo
+                                         (ExpExpressionMember
+                                              (MkExpression NoInfo
+                                                   (ExpName
+                                                    (BareName
+                                                     {| stags := NoInfo;
+                                                        str := "hdr" |})
+                                                    NoLocator)
+                                                   (TypTypeName
+                                                    (BareName
+                                                     {| stags := NoInfo;
+                                                        str := "headers" |}))
+                                                   In)
+                                              {| stags := NoInfo;
+                                                 str := "ipv4" |})
+                                         (TypHeader
+                                          [( {| stags := NoInfo;
+                                                str := "version" |},
+                                             (TypBit 4%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "ihl" |},
+                                             (TypBit 4%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "diffserv" |},
+                                             (TypBit 8%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "totalLen" |},
+                                             (TypBit 16%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "identification" |},
+                                             (TypBit 16%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "flags" |},
+                                             (TypBit 3%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "fragOffset" |},
+                                             (TypBit 13%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "ttl" |},
+                                             (TypBit 8%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "protocol" |},
+                                             (TypBit 8%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "hdrChecksum" |},
+                                             (TypBit 16%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "srcAddr" |},
+                                             (TypBit 32%N) );
+                                           ( {| stags := NoInfo;
+                                                str := "dstAddr" |},
+                                             (TypBit 32%N) )]) Directionless))])
+                             StmUnit)
+                        (BlockCons
+                             (MkStatement NoInfo
+                                  (StatMethodCall
+                                       (MkExpression NoInfo
+                                            (ExpExpressionMember
+                                                 (MkExpression NoInfo
+                                                      (ExpName
+                                                       (BareName
+                                                        {| stags := NoInfo;
+                                                           str := "packet" |})
+                                                       NoLocator)
+                                                      (TypTypeName
+                                                       (BareName
+                                                        {| stags := NoInfo;
+                                                           str := "packet_out" |}))
+                                                      Directionless)
+                                                 {| stags := NoInfo;
+                                                    str := "emit" |})
+                                            (TypFunction
+                                             (MkFunctionType
+                                                  [{| stags := NoInfo;
+                                                      str := "T2" |}]
+                                                  [(MkParameter false In
+                                                        (TypTypeName
+                                                         (BareName
+                                                          {| stags := NoInfo;
+                                                             str := "T2" |}))
+                                                        None
+                                                        {| stags := NoInfo;
+                                                           str := "hdr" |})]
+                                                  FunExtern TypVoid))
+                                            Directionless)
+                                       [(TypHeader
+                                         [( {| stags := NoInfo;
+                                               str := "srcPort" |},
+                                            (TypBit 16%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "dstPort" |},
+                                            (TypBit 16%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "length_" |},
+                                            (TypBit 16%N) );
+                                          ( {| stags := NoInfo;
+                                               str := "checksum" |},
+                                            (TypBit 16%N) )])]
+                                       [(Some
+                                         (MkExpression NoInfo
+                                              (ExpExpressionMember
+                                                   (MkExpression NoInfo
+                                                        (ExpName
+                                                         (BareName
+                                                          {| stags := NoInfo;
+                                                             str := "hdr" |})
+                                                         NoLocator)
+                                                        (TypTypeName
+                                                         (BareName
+                                                          {| stags := NoInfo;
+                                                             str := "headers" |}))
+                                                        In)
+                                                   {| stags := NoInfo;
+                                                      str := "udp" |})
+                                              (TypHeader
+                                               [( {| stags := NoInfo;
+                                                     str := "srcPort" |},
+                                                  (TypBit 16%N) );
+                                                ( {| stags := NoInfo;
+                                                     str := "dstPort" |},
+                                                  (TypBit 16%N) );
+                                                ( {| stags := NoInfo;
+                                                     str := "length_" |},
+                                                  (TypBit 16%N) );
+                                                ( {| stags := NoInfo;
+                                                     str := "checksum" |},
+                                                  (TypBit 16%N) )])
+                                              Directionless))]) StmUnit)
+                             (BlockCons
+                                  (MkStatement NoInfo
+                                       (StatMethodCall
+                                            (MkExpression NoInfo
+                                                 (ExpExpressionMember
+                                                      (MkExpression NoInfo
+                                                           (ExpName
+                                                            (BareName
+                                                             {| stags := NoInfo;
+                                                                str := "packet" |})
+                                                            NoLocator)
+                                                           (TypTypeName
+                                                            (BareName
+                                                             {| stags := NoInfo;
+                                                                str := "packet_out" |}))
+                                                           Directionless)
+                                                      {| stags := NoInfo;
+                                                         str := "emit" |})
+                                                 (TypFunction
+                                                  (MkFunctionType
+                                                       [{| stags := NoInfo;
+                                                           str := "T2" |}]
+                                                       [(MkParameter false In
+                                                             (TypTypeName
+                                                              (BareName
+                                                               {| stags := NoInfo;
+                                                                  str := "T2" |}))
+                                                             None
+                                                             {| stags := NoInfo;
+                                                                str := "hdr" |})]
+                                                       FunExtern TypVoid))
+                                                 Directionless)
+                                            [(TypHeader
+                                              [( {| stags := NoInfo;
+                                                    str := "srcPort" |},
+                                                 (TypBit 16%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "dstPort" |},
+                                                 (TypBit 16%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "seqNo" |},
+                                                 (TypBit 32%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "ackNo" |},
+                                                 (TypBit 32%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "dataOffset" |},
+                                                 (TypBit 4%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "res" |},
+                                                 (TypBit 4%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "flags" |},
+                                                 (TypBit 8%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "window" |},
+                                                 (TypBit 16%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "checksum" |},
+                                                 (TypBit 16%N) );
+                                               ( {| stags := NoInfo;
+                                                    str := "urgentPtr" |},
+                                                 (TypBit 16%N) )])]
+                                            [(Some
+                                              (MkExpression NoInfo
+                                                   (ExpExpressionMember
+                                                        (MkExpression NoInfo
+                                                             (ExpName
+                                                              (BareName
+                                                               {| stags := NoInfo;
+                                                                  str := "hdr" |})
+                                                              NoLocator)
+                                                             (TypTypeName
+                                                              (BareName
+                                                               {| stags := NoInfo;
+                                                                  str := "headers" |}))
+                                                             In)
+                                                        {| stags := NoInfo;
+                                                           str := "tcp" |})
+                                                   (TypHeader
+                                                    [( {| stags := NoInfo;
+                                                          str := "srcPort" |},
+                                                       (TypBit 16%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "dstPort" |},
+                                                       (TypBit 16%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "seqNo" |},
+                                                       (TypBit 32%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "ackNo" |},
+                                                       (TypBit 32%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "dataOffset" |},
+                                                       (TypBit 4%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "res" |},
+                                                       (TypBit 4%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "flags" |},
+                                                       (TypBit 8%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "window" |},
+                                                       (TypBit 16%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "checksum" |},
+                                                       (TypBit 16%N) );
+                                                     ( {| stags := NoInfo;
+                                                          str := "urgentPtr" |},
+                                                       (TypBit 16%N) )])
+                                                   Directionless))]) StmUnit)
+                                  (BlockCons
+                                       (MkStatement NoInfo
+                                            (StatMethodCall
+                                                 (MkExpression NoInfo
+                                                      (ExpExpressionMember
+                                                           (MkExpression
+                                                                NoInfo
+                                                                (ExpName
+                                                                 (BareName
+                                                                  {| 
+                                                                  stags := NoInfo;
+                                                                  str := "packet" |})
+                                                                 NoLocator)
+                                                                (TypTypeName
+                                                                 (BareName
+                                                                  {| 
+                                                                  stags := NoInfo;
+                                                                  str := "packet_out" |}))
+                                                                Directionless)
+                                                           {| stags := NoInfo;
+                                                              str := "emit" |})
+                                                      (TypFunction
+                                                       (MkFunctionType
+                                                            [{| stags := NoInfo;
+                                                                str := "T2" |}]
+                                                            [(MkParameter
+                                                                  false In
+                                                                  (TypTypeName
+                                                                   (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "T2" |}))
+                                                                  None
+                                                                  {| 
+                                                                  stags := NoInfo;
+                                                                  str := "hdr" |})]
+                                                            FunExtern
+                                                            TypVoid))
+                                                      Directionless)
+                                                 [(TypHeader
+                                                   [( {| stags := NoInfo;
+                                                         str := "typeCode" |},
+                                                      (TypBit 16%N) );
+                                                    ( {| stags := NoInfo;
+                                                         str := "hdrChecksum" |},
+                                                      (TypBit 16%N) )])]
+                                                 [(Some
+                                                   (MkExpression NoInfo
+                                                        (ExpExpressionMember
+                                                             (MkExpression
+                                                                  NoInfo
+                                                                  (ExpName
+                                                                   (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "hdr" |})
+                                                                   NoLocator)
+                                                                  (TypTypeName
+                                                                   (BareName
+                                                                    {| 
+                                                                    stags := NoInfo;
+                                                                    str := "headers" |}))
+                                                                  In)
+                                                             {| stags := NoInfo;
+                                                                str := "icmp" |})
+                                                        (TypHeader
+                                                         [( {| stags := NoInfo;
+                                                               str := "typeCode" |},
+                                                            (TypBit 16%N) );
+                                                          ( {| stags := NoInfo;
+                                                               str := "hdrChecksum" |},
+                                                            (TypBit 16%N) )])
+                                                        Directionless))])
+                                            StmUnit) (BlockEmpty NoInfo)))))))).
+
+Definition verifyChecksum := DeclControl NoInfo
+    {| stags := NoInfo; str := "verifyChecksum" |} nil
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          None {| stags := NoInfo; str := "meta" |})] nil nil
+    (BlockEmpty NoInfo).
+
+Definition computeChecksum := DeclControl NoInfo
+    {| stags := NoInfo; str := "computeChecksum" |} nil
+    [(MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "headers" |}))
+          None {| stags := NoInfo; str := "hdr" |});
+     (MkParameter false InOut
+          (TypTypeName (BareName {| stags := NoInfo; str := "metadata" |}))
+          None {| stags := NoInfo; str := "meta" |})] nil nil
+    (BlockEmpty NoInfo).
+
+Definition main := DeclInstantiation NoInfo
+    (TypSpecializedType
+         (TypTypeName (BareName {| stags := NoInfo; str := "V1Switch" |}))
+         [(TypStruct
+           [( {| stags := NoInfo; str := "ethernet" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "dstAddr" |}, (TypBit 48%N) );
+                ( {| stags := NoInfo; str := "srcAddr" |}, (TypBit 48%N) );
+                ( {| stags := NoInfo; str := "etherType" |}, (TypBit 16%N) )]) );
+            ( {| stags := NoInfo; str := "icmp" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "typeCode" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "hdrChecksum" |},
+                  (TypBit 16%N) )]) );
+            ( {| stags := NoInfo; str := "ipv4" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "version" |}, (TypBit 4%N) );
+                ( {| stags := NoInfo; str := "ihl" |}, (TypBit 4%N) );
+                ( {| stags := NoInfo; str := "diffserv" |}, (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "totalLen" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "identification" |},
+                  (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "flags" |}, (TypBit 3%N) );
+                ( {| stags := NoInfo; str := "fragOffset" |}, (TypBit 13%N) );
+                ( {| stags := NoInfo; str := "ttl" |}, (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "protocol" |}, (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "hdrChecksum" |},
+                  (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "srcAddr" |}, (TypBit 32%N) );
+                ( {| stags := NoInfo; str := "dstAddr" |}, (TypBit 32%N) )]) );
+            ( {| stags := NoInfo; str := "ipv6" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "version" |}, (TypBit 4%N) );
+                ( {| stags := NoInfo; str := "trafficClass" |},
+                  (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "flowLabel" |}, (TypBit 20%N) );
+                ( {| stags := NoInfo; str := "payloadLen" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "nextHdr" |}, (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "hopLimit" |}, (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "srcAddr" |}, (TypBit 128%N) );
+                ( {| stags := NoInfo; str := "dstAddr" |}, (TypBit 128%N) )]) );
+            ( {| stags := NoInfo; str := "tcp" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "srcPort" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "dstPort" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "seqNo" |}, (TypBit 32%N) );
+                ( {| stags := NoInfo; str := "ackNo" |}, (TypBit 32%N) );
+                ( {| stags := NoInfo; str := "dataOffset" |}, (TypBit 4%N) );
+                ( {| stags := NoInfo; str := "res" |}, (TypBit 4%N) );
+                ( {| stags := NoInfo; str := "flags" |}, (TypBit 8%N) );
+                ( {| stags := NoInfo; str := "window" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "checksum" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "urgentPtr" |}, (TypBit 16%N) )]) );
+            ( {| stags := NoInfo; str := "udp" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "srcPort" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "dstPort" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "length_" |}, (TypBit 16%N) );
+                ( {| stags := NoInfo; str := "checksum" |}, (TypBit 16%N) )]) );
+            ( {| stags := NoInfo; str := "vlan_tag" |},
+              (TypHeader
+               [( {| stags := NoInfo; str := "pcp" |}, (TypBit 3%N) );
+                ( {| stags := NoInfo; str := "cfi" |}, (TypBit 1%N) );
+                ( {| stags := NoInfo; str := "vid" |}, (TypBit 12%N) );
+                ( {| stags := NoInfo; str := "etherType" |}, (TypBit 16%N) )]) )]);
+          (TypStruct
+           [( {| stags := NoInfo; str := "ing_metadata" |},
+              (TypStruct
+               [( {| stags := NoInfo; str := "drop" |}, (TypBit 1%N) );
+                ( {| stags := NoInfo; str := "egress_port" |}, (TypBit 9%N) );
+                ( {| stags := NoInfo; str := "packet_type" |}, (TypBit 4%N) )]) )])])
+    [(MkExpression NoInfo
+          (ExpNamelessInstantiation
+               (TypSpecializedType
+                    (TypTypeName
+                     (BareName {| stags := NoInfo; str := "ParserImpl" |}))
+                    nil) nil)
+          (TypParser
+           (MkControlType nil
+                [(MkParameter false Directionless
+                      (TypExtern {| stags := NoInfo; str := "packet_in" |})
+                      None {| stags := NoInfo; str := "packet" |});
+                 (MkParameter false Out
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ethernet" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "icmp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "typeCode" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv4" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "ihl" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "diffserv" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "totalLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "identification" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "fragOffset" |},
+                              (TypBit 13%N) );
+                            ( {| stags := NoInfo; str := "ttl" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "protocol" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 32%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv6" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "trafficClass" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "flowLabel" |},
+                              (TypBit 20%N) );
+                            ( {| stags := NoInfo; str := "payloadLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "nextHdr" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hopLimit" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 128%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 128%N) )]) );
+                        ( {| stags := NoInfo; str := "tcp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "seqNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "ackNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dataOffset" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "res" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "window" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "urgentPtr" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "udp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "length_" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "vlan_tag" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "pcp" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "cfi" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "vid" |},
+                              (TypBit 12%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) )]) None
+                      {| stags := NoInfo; str := "hdr" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ing_metadata" |},
+                          (TypStruct
+                           [( {| stags := NoInfo; str := "drop" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "egress_port" |},
+                              (TypBit 9%N) );
+                            ( {| stags := NoInfo; str := "packet_type" |},
+                              (TypBit 4%N) )]) )]) None
+                      {| stags := NoInfo; str := "meta" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ingress_port" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "egress_spec" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "egress_port" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "instance_type" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "packet_length" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "enq_timestamp" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "enq_qdepth" |},
+                          (TypBit 19%N) );
+                        ( {| stags := NoInfo; str := "deq_timedelta" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "deq_qdepth" |},
+                          (TypBit 19%N) );
+                        ( {| stags := NoInfo;
+                             str := "ingress_global_timestamp" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo;
+                             str := "egress_global_timestamp" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo; str := "mcast_grp" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "egress_rid" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "checksum_error" |},
+                          (TypBit 1%N) );
+                        ( {| stags := NoInfo; str := "parser_error" |},
+                          TypError );
+                        ( {| stags := NoInfo; str := "priority" |},
+                          (TypBit 3%N) )]) None
+                      {| stags := NoInfo; str := "standard_metadata" |})]))
+          Directionless);
+     (MkExpression NoInfo
+          (ExpNamelessInstantiation
+               (TypSpecializedType
+                    (TypTypeName
+                     (BareName
+                      {| stags := NoInfo; str := "verifyChecksum" |})) nil)
+               nil)
+          (TypControl
+           (MkControlType nil
+                [(MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ethernet" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "icmp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "typeCode" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv4" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "ihl" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "diffserv" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "totalLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "identification" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "fragOffset" |},
+                              (TypBit 13%N) );
+                            ( {| stags := NoInfo; str := "ttl" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "protocol" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 32%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv6" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "trafficClass" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "flowLabel" |},
+                              (TypBit 20%N) );
+                            ( {| stags := NoInfo; str := "payloadLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "nextHdr" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hopLimit" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 128%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 128%N) )]) );
+                        ( {| stags := NoInfo; str := "tcp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "seqNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "ackNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dataOffset" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "res" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "window" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "urgentPtr" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "udp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "length_" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "vlan_tag" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "pcp" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "cfi" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "vid" |},
+                              (TypBit 12%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) )]) None
+                      {| stags := NoInfo; str := "hdr" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ing_metadata" |},
+                          (TypStruct
+                           [( {| stags := NoInfo; str := "drop" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "egress_port" |},
+                              (TypBit 9%N) );
+                            ( {| stags := NoInfo; str := "packet_type" |},
+                              (TypBit 4%N) )]) )]) None
+                      {| stags := NoInfo; str := "meta" |})])) Directionless);
+     (MkExpression NoInfo
+          (ExpNamelessInstantiation
+               (TypSpecializedType
+                    (TypTypeName
+                     (BareName {| stags := NoInfo; str := "ingress" |})) nil)
+               nil)
+          (TypControl
+           (MkControlType nil
+                [(MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ethernet" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "icmp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "typeCode" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv4" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "ihl" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "diffserv" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "totalLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "identification" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "fragOffset" |},
+                              (TypBit 13%N) );
+                            ( {| stags := NoInfo; str := "ttl" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "protocol" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 32%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv6" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "trafficClass" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "flowLabel" |},
+                              (TypBit 20%N) );
+                            ( {| stags := NoInfo; str := "payloadLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "nextHdr" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hopLimit" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 128%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 128%N) )]) );
+                        ( {| stags := NoInfo; str := "tcp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "seqNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "ackNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dataOffset" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "res" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "window" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "urgentPtr" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "udp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "length_" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "vlan_tag" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "pcp" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "cfi" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "vid" |},
+                              (TypBit 12%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) )]) None
+                      {| stags := NoInfo; str := "hdr" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ing_metadata" |},
+                          (TypStruct
+                           [( {| stags := NoInfo; str := "drop" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "egress_port" |},
+                              (TypBit 9%N) );
+                            ( {| stags := NoInfo; str := "packet_type" |},
+                              (TypBit 4%N) )]) )]) None
+                      {| stags := NoInfo; str := "meta" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ingress_port" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "egress_spec" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "egress_port" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "instance_type" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "packet_length" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "enq_timestamp" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "enq_qdepth" |},
+                          (TypBit 19%N) );
+                        ( {| stags := NoInfo; str := "deq_timedelta" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "deq_qdepth" |},
+                          (TypBit 19%N) );
+                        ( {| stags := NoInfo;
+                             str := "ingress_global_timestamp" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo;
+                             str := "egress_global_timestamp" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo; str := "mcast_grp" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "egress_rid" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "checksum_error" |},
+                          (TypBit 1%N) );
+                        ( {| stags := NoInfo; str := "parser_error" |},
+                          TypError );
+                        ( {| stags := NoInfo; str := "priority" |},
+                          (TypBit 3%N) )]) None
+                      {| stags := NoInfo; str := "standard_metadata" |})]))
+          Directionless);
+     (MkExpression NoInfo
+          (ExpNamelessInstantiation
+               (TypSpecializedType
+                    (TypTypeName
+                     (BareName {| stags := NoInfo; str := "egress" |})) nil)
+               nil)
+          (TypControl
+           (MkControlType nil
+                [(MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ethernet" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "icmp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "typeCode" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv4" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "ihl" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "diffserv" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "totalLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "identification" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "fragOffset" |},
+                              (TypBit 13%N) );
+                            ( {| stags := NoInfo; str := "ttl" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "protocol" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 32%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv6" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "trafficClass" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "flowLabel" |},
+                              (TypBit 20%N) );
+                            ( {| stags := NoInfo; str := "payloadLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "nextHdr" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hopLimit" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 128%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 128%N) )]) );
+                        ( {| stags := NoInfo; str := "tcp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "seqNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "ackNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dataOffset" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "res" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "window" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "urgentPtr" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "udp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "length_" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "vlan_tag" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "pcp" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "cfi" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "vid" |},
+                              (TypBit 12%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) )]) None
+                      {| stags := NoInfo; str := "hdr" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ing_metadata" |},
+                          (TypStruct
+                           [( {| stags := NoInfo; str := "drop" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "egress_port" |},
+                              (TypBit 9%N) );
+                            ( {| stags := NoInfo; str := "packet_type" |},
+                              (TypBit 4%N) )]) )]) None
+                      {| stags := NoInfo; str := "meta" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ingress_port" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "egress_spec" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "egress_port" |},
+                          (TypBit 9%N) );
+                        ( {| stags := NoInfo; str := "instance_type" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "packet_length" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "enq_timestamp" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "enq_qdepth" |},
+                          (TypBit 19%N) );
+                        ( {| stags := NoInfo; str := "deq_timedelta" |},
+                          (TypBit 32%N) );
+                        ( {| stags := NoInfo; str := "deq_qdepth" |},
+                          (TypBit 19%N) );
+                        ( {| stags := NoInfo;
+                             str := "ingress_global_timestamp" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo;
+                             str := "egress_global_timestamp" |},
+                          (TypBit 48%N) );
+                        ( {| stags := NoInfo; str := "mcast_grp" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "egress_rid" |},
+                          (TypBit 16%N) );
+                        ( {| stags := NoInfo; str := "checksum_error" |},
+                          (TypBit 1%N) );
+                        ( {| stags := NoInfo; str := "parser_error" |},
+                          TypError );
+                        ( {| stags := NoInfo; str := "priority" |},
+                          (TypBit 3%N) )]) None
+                      {| stags := NoInfo; str := "standard_metadata" |})]))
+          Directionless);
+     (MkExpression NoInfo
+          (ExpNamelessInstantiation
+               (TypSpecializedType
+                    (TypTypeName
+                     (BareName
+                      {| stags := NoInfo; str := "computeChecksum" |})) nil)
+               nil)
+          (TypControl
+           (MkControlType nil
+                [(MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ethernet" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "icmp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "typeCode" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv4" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "ihl" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "diffserv" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "totalLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "identification" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "fragOffset" |},
+                              (TypBit 13%N) );
+                            ( {| stags := NoInfo; str := "ttl" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "protocol" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 32%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv6" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "trafficClass" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "flowLabel" |},
+                              (TypBit 20%N) );
+                            ( {| stags := NoInfo; str := "payloadLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "nextHdr" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hopLimit" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 128%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 128%N) )]) );
+                        ( {| stags := NoInfo; str := "tcp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "seqNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "ackNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dataOffset" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "res" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "window" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "urgentPtr" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "udp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "length_" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "vlan_tag" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "pcp" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "cfi" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "vid" |},
+                              (TypBit 12%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) )]) None
+                      {| stags := NoInfo; str := "hdr" |});
+                 (MkParameter false InOut
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ing_metadata" |},
+                          (TypStruct
+                           [( {| stags := NoInfo; str := "drop" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "egress_port" |},
+                              (TypBit 9%N) );
+                            ( {| stags := NoInfo; str := "packet_type" |},
+                              (TypBit 4%N) )]) )]) None
+                      {| stags := NoInfo; str := "meta" |})])) Directionless);
+     (MkExpression NoInfo
+          (ExpNamelessInstantiation
+               (TypSpecializedType
+                    (TypTypeName
+                     (BareName {| stags := NoInfo; str := "DeparserImpl" |}))
+                    nil) nil)
+          (TypControl
+           (MkControlType nil
+                [(MkParameter false Directionless
+                      (TypExtern {| stags := NoInfo; str := "packet_out" |})
+                      None {| stags := NoInfo; str := "packet" |});
+                 (MkParameter false In
+                      (TypStruct
+                       [( {| stags := NoInfo; str := "ethernet" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 48%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "icmp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "typeCode" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv4" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "ihl" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "diffserv" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "totalLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "identification" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "fragOffset" |},
+                              (TypBit 13%N) );
+                            ( {| stags := NoInfo; str := "ttl" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "protocol" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hdrChecksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 32%N) )]) );
+                        ( {| stags := NoInfo; str := "ipv6" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "version" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "trafficClass" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "flowLabel" |},
+                              (TypBit 20%N) );
+                            ( {| stags := NoInfo; str := "payloadLen" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "nextHdr" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "hopLimit" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "srcAddr" |},
+                              (TypBit 128%N) );
+                            ( {| stags := NoInfo; str := "dstAddr" |},
+                              (TypBit 128%N) )]) );
+                        ( {| stags := NoInfo; str := "tcp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "seqNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "ackNo" |},
+                              (TypBit 32%N) );
+                            ( {| stags := NoInfo; str := "dataOffset" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "res" |},
+                              (TypBit 4%N) );
+                            ( {| stags := NoInfo; str := "flags" |},
+                              (TypBit 8%N) );
+                            ( {| stags := NoInfo; str := "window" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "urgentPtr" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "udp" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "srcPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "dstPort" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "length_" |},
+                              (TypBit 16%N) );
+                            ( {| stags := NoInfo; str := "checksum" |},
+                              (TypBit 16%N) )]) );
+                        ( {| stags := NoInfo; str := "vlan_tag" |},
+                          (TypHeader
+                           [( {| stags := NoInfo; str := "pcp" |},
+                              (TypBit 3%N) );
+                            ( {| stags := NoInfo; str := "cfi" |},
+                              (TypBit 1%N) );
+                            ( {| stags := NoInfo; str := "vid" |},
+                              (TypBit 12%N) );
+                            ( {| stags := NoInfo; str := "etherType" |},
+                              (TypBit 16%N) )]) )]) None
+                      {| stags := NoInfo; str := "hdr" |})])) Directionless)]
+    {| stags := NoInfo; str := "main" |} nil.
+
+Definition prog := Program
+    [decl'1; packet_in; packet_out; verify'check'toSignal; NoAction; decl'2;
+     decl'3; standard_metadata_t; CounterType; MeterType; counter;
+     direct_counter; meter; direct_meter; register; action_profile;
+     random'result'lo'hi; digest'receiver'data; HashAlgorithm; mark_to_drop;
+     mark_to_drop'standard_metadata; hash'result'algo'base'data'max;
+     action_selector; CloneType; Checksum16;
+     verify_checksum'condition'data'checksum'algo;
+     update_checksum'condition'data'checksum'algo;
+     verify_checksum_with_payload'condition'data'checksum'algo;
+     update_checksum_with_payload'condition'data'checksum'algo;
+     resubmit'data; recirculate'data; clone'type'session;
+     clone3'type'session'data; truncate'length; assert'check; assume'check;
+     log_msg'msg; log_msg'msg'data; Parser; VerifyChecksum; Ingress; Egress;
+     ComputeChecksum; Deparser; V1Switch; ingress_metadata_t; ethernet_t;
+     icmp_t; ipv4_t; ipv6_t; tcp_t; udp_t; vlan_tag_t; metadata; headers;
+     ParserImpl; egress; ingress; DeparserImpl; verifyChecksum;
+     computeChecksum; main].
+
+

--- a/deps/poulet4/lib/P4cub/ToGCLTest.v
+++ b/deps/poulet4/lib/P4cub/ToGCLTest.v
@@ -1,7 +1,5 @@
 Require Import Poulet4.P4defs.
 Require Import Poulet4.Syntax.
-Require Import Poulet4.LightExamples.SimpleNat.
-Require Import Poulet4.LightExamples.ECMP2.
 Require Import Poulet4.P4cub.Util.Result.
 Require Import Poulet4.ToP4cubTest.
 Require Import Poulet4.P4cub.Envn.
@@ -12,6 +10,12 @@ Require Import Poulet4.P4cub.V1model.
 Require Poulet4.P4cub.GCL.
 Require Poulet4.P4cub.ToGCL.
 Import Result ResultNotations Syntax List ListNotations.
+
+
+(* Import the Test programs *)
+Require Import Poulet4.LightExamples.SimpleNat.
+Require Import Poulet4.LightExamples.ECMP2.
+Require Import Poulet4.LightExamples.MultiProtocol.
 
 
 Module GCL := GCL.GCL.
@@ -44,9 +48,7 @@ Definition simple_nat_inline_test : result (Inline.t Info) :=
 Lemma simple_nat_test1 : is_ok simple_nat_test_case.
 Proof. compute. trivial. Qed.
 
-
-Import ECMP2.
-
+(* ECMP2 *)
 Definition p4cub_ecmp2 := ToP4cub.translate_program Info NoInfo ECMP2.prog.
 
 Definition ecmp2_test_case :=
@@ -58,4 +60,20 @@ Definition ecmp2_test_case :=
 (* Compute ecmp2_test_case. *)
 
 Lemma ecmp2_test : is_ok ecmp2_test_case.
+Proof. compute. trivial. Qed.
+
+
+(* 07-Multi-Protocol *)
+
+Definition p4cub_multiprotocol := ToP4cub.translate_program Info NoInfo MultiProtocol.prog.
+
+Definition multiprotocol_test_case :=
+  let* sn := p4cub_multiprotocol in
+  let externs := V1model.externs in
+  ToGCL.from_p4cub Info TableInstr.instr 1000 externs (V1model.package NoInfo) sn.
+
+(* Compute p4cub_multiprotocol. *)
+(* Compute multiprotocol_test_case. *)
+
+Lemma multiprotocol_test : is_ok multiprotocol_test_case.
 Proof. compute. trivial. Qed.

--- a/deps/poulet4/lib/P4cub/Util/ListUtil.v
+++ b/deps/poulet4/lib/P4cub/Util/ListUtil.v
@@ -239,6 +239,16 @@ Definition fold_righti {A B : Type} (f : nat -> A -> B -> B) (init : B) (xs : li
 Definition fold_lefti { A B : Type } (f : nat -> A -> B -> B) (init : B) (lst : list A) : B :=
   snd (fold_left (fun '(n, b) a => (S n, f n a b)) lst (O, init)).
 
+Definition findi { A : Type } (select : A -> bool) (l : list A) : option nat :=
+  fold_lefti (fun i a found_at_n =>
+                match found_at_n with
+                | Some _ => found_at_n
+                | None => if select a
+                          then Some i
+                          else None
+                end
+             ) None l.
+
 Definition union_map_snd {A B C : Type} (f : B -> result C) (xs : list (A * B)) : result (list (A * C)) :=
   rred (List.map (snd_res_map f) xs).
 

--- a/deps/poulet4/lib/ToP4cub.v
+++ b/deps/poulet4/lib/ToP4cub.v
@@ -1,6 +1,7 @@
 Set Warnings "-custom-entry-overridden".
 Require Export Poulet4.Syntax.
 Require Import Poulet4.SimplExpr.
+Require Import Poulet4.P4cub.Util.ListUtil.
 Require Export
         Poulet4.P4cub.Syntax.Syntax
         Poulet4.P4cub.Syntax.Substitution
@@ -778,12 +779,62 @@ Section ToP4cub.
       None
     end.
 
-  Fixpoint translate_statement_switch_case (ssw : @StatementSwitchCase tags_t) : result (ST.s tags_t) :=
+  Definition get_label_index (tenum : list (P4String.t tags_t))  (label : P4String.t tags_t) : result Z :=
+    match ListUtil.findi (P4String.equivb label) tenum with
+    | Some i =>
+      ok (BinInt.Z.of_nat i)
+    | None =>
+      error ("[ERROR] Couldnt find label [" ++ P4String.str label ++ "] in enum")
+    end.
+
+  Print P4Type.
+
+  Definition get_enum_type (expression : @Expression tags_t) : result (list (P4String.t tags_t)) :=
+    let '(MkExpression tags pre_expr type dir) := expression in
+    match type with
+    | TypEnum _ _ variants =>
+      ok variants
+    | _ =>
+      error "could not get enum type from non-enum variant"
+    end.
+
+  Fixpoint translate_statement_switch_case ctx (match_expr : E.e tags_t) (bits : N) (tenum : list (P4String.t tags_t)) (acc : (option (E.e tags_t)) * (ST.s tags_t -> ST.s tags_t)) (ssw : @StatementSwitchCase tags_t) : result ((option (E.e tags_t)) * (ST.s tags_t -> ST.s tags_t)) :=
+    (* break apart the accumulation into the aggregated condition and the aggregated if-then continuation *)
+    let '(cond_opt, ifthen) := acc in
+    (* Force the agggregated conditional to be a boolean *)
+    let acc_cond := fun tags => SyntaxUtil.force (E.EBool false tags) cond_opt in
+    (* Build the case match by building the label index check and or-ing the aggregated conditional *)
+    let case_match := fun tags label =>
+                        let+ val := get_label_index tenum label in
+                        let mtch := E.EBop E.TBool E.Eq match_expr (E.EBit bits val tags) tags in
+                        E.EBop E.TBool E.Or (acc_cond tags) mtch tags in
+    (* check the cases *)
     match ssw with
-    | StatSwCaseAction tags label code =>
-      error "[FIXME] switch case action unimplemented"
+    | StatSwCaseAction tags label block =>
+      (* This case discharges the built up conditions. so the first part of the pair is always None *)
+      match label with
+      | StatSwLabName tags labname =>
+        let* cond := case_match tags labname in
+        let* st := translate_block ctx tags block in
+        let else__ifthen : ST.s tags_t -> ST.s tags_t := fun else_ => ST.SConditional cond st else_ tags in
+        (* The continuation is still "open" *)
+        ok (None, ifthen ∘ else__ifthen)
+      | StatSwLabDefault tags =>
+        let* else_ := translate_block ctx tags block in
+        (* in the default case, we throw away the argument because we have the else case, *)
+        (* if anything comes after, its dead code *)
+        ok (None, fun (_ : ST.s tags_t) => (ifthen else_ : ST.s tags_t))
+      end
     | StatSwCaseFallThrough tags label =>
-      error "[FIXME] switch case fall through unimplemented"
+      match label with
+      | StatSwLabDefault _ =>
+        error "[ERROR] Cannot have default label as a fall-through case in a switch statement"
+      | StatSwLabName tags labname =>
+        (* This case doesn't change the continuation but accumulates a condition *)
+        (* Note that the accumulation happens automagically in the [case_match function]*)
+        let+ cond := case_match tags labname in
+        (Some cond, (ifthen : ST.s tags_t -> ST.s tags_t))
+      end
     end
   with translate_statement_pre_t (ctx : DeclCtx) (i : tags_t) (pre_s : @StatementPreT tags_t) : result (ST.s tags_t) :=
     match pre_s with
@@ -796,12 +847,6 @@ Section ToP4cub.
         match typ with
         | TypFunction (MkFunctionType type_params parameters kind ret) =>
           translate_function_application tags n ("$RETVAR_" ++ (P4String.str n)) ret type_args parameters args
-          (* let* cub_args := rred (List.map (translate_expression_and_type i) (optionlist_to_list args)) in *)
-          (* let* params := parameters_to_params tags parameters in *)
-          (* let* paramargs := apply_args_to_params params cub_args in *)
-          (* let+ ret_typ := translate_return_type tags ret in *)
-          (* let cub_ret := option_map (fun t => (t, E.EVar t ("$RETVAR_" ++ (P4String.str n)) tags)) ret_typ in *)
-          (* ST.SFunCall (P4String.str n) [] (Arrow paramargs cub_ret) tags *)
         | _ => error "A name, applied like a method call, must be a function or extern type; I got something else"
         end
       | _ => error "ERROR :: Cannot handle this kind of expression"
@@ -836,7 +881,17 @@ Section ToP4cub.
         ok (ST.SReturn None i)
       end
     | StatSwitch expr cases =>
-      error "[FIXME] switch statement not implemented"
+      let* tenum := get_enum_type expr in
+      let bits := BinNat.N.of_nat (PeanoNat.Nat.log2_up (List.length tenum)) in
+      let* expr := translate_expression expr in
+      let+ (_, cases_as_ifs) :=
+          List.fold_left (fun acc_res switch_case =>
+                            let* acc := acc_res in
+                            translate_statement_switch_case ctx expr bits tenum acc switch_case
+                         ) cases (ok (None, fun x => x))
+
+      in
+      cases_as_ifs (ST.SSkip i)
     | StatConstant typ name value loc =>
       error "Constant Statement should not occur"
     | StatVariable typ name init loc =>

--- a/deps/poulet4/lib/ToP4cubTest.v
+++ b/deps/poulet4/lib/ToP4cubTest.v
@@ -2,14 +2,15 @@ Require Import Poulet4.P4defs.
 Require Import Poulet4.Syntax.
 Require Import Poulet4.LightExamples.SimpleNat.
 Require Import Poulet4.LightExamples.ECMP2.
+Require Import Poulet4.LightExamples.MultiProtocol.
 Require Import Poulet4.P4cub.Util.Result.
 Require Import Poulet4.ToP4cub.
 
 Import Result Syntax List ListNotations.
 
 (* The Test Programs*)
-Import SimpleNat.
 
+(* Test Lemma For simple_nat.p4*)
 (* Compute (translate_program Info NoInfo SimpleNat.prog). *)
 Lemma simplenat_no_error: Result.is_ok (translate_program Info NoInfo SimpleNat.prog).
 Proof.
@@ -17,14 +18,23 @@ Proof.
   trivial.
 Qed.
 
-Import ECMP2.
-
 (* Compute ECMP2.prog. *)
 
+(* Test lemma for ecmp_2.v *)
 (* Compute (translate_program Info NoInfo ECMP2.prog). *)
 (* CAVEAT EMPTOR.  I swapped all the "selector" matchkinds in ECMP2.prog for "exact" *)
 (* TODO When we add support for arbitrary matchkinds, regenerate ECMP2 so that it uses "selector".  *)
 Lemma ecmp2_no_error: Result.is_ok (translate_program Info NoInfo ECMP2.prog).
+Proof.
+  compute.
+  trivial.
+Qed.
+
+
+(* Compute (translate_program Info NoInfo MultiProtocol.prog). *)
+
+Lemma multiprotocol_no_error :
+  Result.is_ok (translate_program Info NoInfo MultiProtocol.prog).
 Proof.
   compute.
   trivial.


### PR DESCRIPTION
Reconcile conflicts between #290 and #286 that broke `poulet4`, necessitating #292.

Essentially #286 removed `BareNames` in some places that cause `MultiProtocol.v` not to build.

They've been fixed, and it builds for me now.