### PR TITLE
build-poulet4 workflow added

### DIFF
--- a/.github/workflows/build-poulet4.yml
+++ b/.github/workflows/build-poulet4.yml
@@ -9,7 +9,7 @@ on:
    branches: [ poulet4 ]
 
   # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+ workflow_dispatch:
 
 # # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -32,7 +32,7 @@ jobs:
       - name: build-ubuntu
         # Runs the script to build poulet4 on ubuntu
         run: ./.github/scripts/build-poulet4-ubuntu.sh
-#         shell: bash
+        shell: bash
 
   build-macos-latest:
     runs-on: macos-latest

--- a/.github/workflows/build-poulet4.yml
+++ b/.github/workflows/build-poulet4.yml
@@ -13,25 +13,25 @@ on:
 
 # # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-#   # This workflow contains two jobs called "build-ubuntu" and "build-macos"
-#   build-ubuntu:
-#     # The type of runner that the job will run on
-#     runs-on: ubuntu-latest
+  # This workflow contains two jobs called "build-ubuntu" and "build-macos"
+  build-ubuntu:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
 
-#     # Steps represent a sequence of tasks that will be executed as part of the job
-#     steps: 
-#       - name: checkout-main
-#         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#         uses: actions/checkout@main
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps: 
+      - name: checkout-main
+        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        uses: actions/checkout@main
       
-#       - name: setup-ocaml
-#         uses: ocaml/setup-ocaml@v1
-#         with:
-#           ocaml-version: '4.12.0'
+      - name: setup-ocaml
+        uses: ocaml/setup-ocaml@v1
+        with:
+          ocaml-version: '4.12.0'
 
-#       - name: build-ubuntu
-#         # Runs the script to build poulet4 on ubuntu
-#         run: ./.github/scripts/build-poulet4-ubuntu.sh
+      - name: build-ubuntu
+        # Runs the script to build poulet4 on ubuntu
+        run: ./.github/scripts/build-poulet4-ubuntu.sh
 #         shell: bash
 
   build-macos-latest:

--- a/.github/workflows/build-poulet4.yml
+++ b/.github/workflows/build-poulet4.yml
@@ -3,10 +3,10 @@ name: build-poulet4
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
-#  push:
-#    branches: [ poulet4 ]
-#  pull_request:
-#    branches: [ poulet4 ]
+ push:
+   branches: [ poulet4 ]
+ pull_request:
+   branches: [ poulet4 ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This PR adds the build-poulet4 workflow which runs on push or PR on the poulet4 branch.

Note, you need to have this workflow in the poulet4 branch to run it manually.