### PR TITLE
Poulet4 extraction warnings

### DIFF
--- a/deps/poulet4/extraction/Extract.v
+++ b/deps/poulet4/extraction/Extract.v
@@ -1,3 +1,4 @@
+Set Warnings "-extraction-reserved-identifier".
 Require Coq.extraction.Extraction.
 Require Import Coq.extraction.ExtrOcamlBasic.
 Require Import Coq.extraction.ExtrOcamlNativeString.

--- a/deps/poulet4/extraction/Extract.v
+++ b/deps/poulet4/extraction/Extract.v
@@ -1,9 +1,18 @@
 Require Coq.extraction.Extraction.
 Require Import Coq.extraction.ExtrOcamlBasic.
 Require Import Coq.extraction.ExtrOcamlNativeString.
-Require Import Coq.extraction.ExtrOcamlNatInt.
 
 Require Import Coq.Numbers.BinNums.
+
+Extract Inductive nat =>
+int [ "0" "Stdlib.Int.succ" ]
+    "(fun fO fS n -> if n=0 then fO () else fS (n-1))".
+
+Extract Constant pred => "fun n -> Stdlib.max 0 (n-1)".
+Extract Constant minus => "fun n m -> Stdlib.max 0 (n-m)".
+
+Extract Inlined Constant max => "Stdlib.max".
+Extract Inlined Constant min => "Stdlib.min".
 
 Extract Inductive positive => "Bigint.t"
   [ "(fun p -> Bigint.of_zarith_bigint (Zarith.Z.succ (Zarith.Z.mul (Zarith.Z.of_int 2) (Bigint.to_zarith_bigint p))))"

--- a/deps/poulet4/extraction/dune
+++ b/deps/poulet4/extraction/dune
@@ -24,4 +24,4 @@
   (name poulet4)
   (public_name poulet4)
   (libraries bignum zarith)
-  (flags (:standard -w -33)))
+  (flags (:standard -w -33 -w -20)))

--- a/deps/poulet4/lib/GenLoc.v
+++ b/deps/poulet4/lib/GenLoc.v
@@ -495,7 +495,7 @@ Section Transformer.
   Definition transform_prog (prog: @program tags_t): @program tags_t + exception :=
     match prog with
     | Program decls =>
-      match (transform_decls LGlobal IdentMap.empty decls) nil with
+      match transform_decls LGlobal IdentMap.empty decls nil with
       | (inl (decls', _), _) => inl (Program decls')
       | (inr ex, _) => inr ex
       end

--- a/deps/poulet4/lib/Monads/Error.v
+++ b/deps/poulet4/lib/Monads/Error.v
@@ -41,4 +41,4 @@ Definition strip_error {Error Result: Type} (x: @error_monad Error Result) : opt
   | inr _ => None
   end.
 
-Hint Unfold error_ret error_bind : core.
+Global Hint Unfold error_ret error_bind : core.

--- a/deps/poulet4/lib/Monads/Hoare/SP.v
+++ b/deps/poulet4/lib/Monads/Hoare/SP.v
@@ -12,7 +12,7 @@ Open Scope hoare_scope.
 
 Definition Pred {State: Type} := State -> Prop.
 Definition top {State: Type} : @Pred State := fun _ => True.
-Hint Unfold top : core.
+Global Hint Unfold top : core.
 
 Definition hoare_triple_partial
     {State Exception Result: Type}

--- a/deps/poulet4/lib/Monads/Hoare/WP.v
+++ b/deps/poulet4/lib/Monads/Hoare/WP.v
@@ -20,9 +20,8 @@ Definition Post (State: Type) (Value: Type) := Value -> Pred State.
 Definition top {State: Type} : Pred State := fun _ => True.
 Definition bot {State: Type} : Pred State := fun _ => False.
 
-Hint Unfold top : core.
-Hint Unfold bot: core.
-
+Global Hint Unfold top : core.
+Global Hint Unfold bot: core.
 
 Definition hoare_total_wp
   {State Exception Result: Type}

--- a/deps/poulet4/lib/Monads/Monad.v
+++ b/deps/poulet4/lib/Monads/Monad.v
@@ -5,7 +5,7 @@ Class Monad (M : Type -> Type) : Type :=
     mbind : forall {A B}, M A -> (A -> M B) -> M B
   }.
 
-Hint Unfold mret mbind.
+Global Hint Unfold mret mbind : core.
 
 (* Adapted from coq-ext-lib *)
 (* https://github.com/coq-community/coq-ext-lib/blob/v8.5/theories/Structures/Monad.v*)

--- a/deps/poulet4/lib/Monads/Option.v
+++ b/deps/poulet4/lib/Monads/Option.v
@@ -29,7 +29,7 @@ Fixpoint reduce_option {A : Type} (acts: list (option A)) (f : A -> A -> A) (bas
   | Some x :: xs => reduce_option xs f (f x base)
   end.
 
-Hint Unfold option_ret option_bind : core.
+Global Hint Unfold option_ret option_bind : core.
 
 Lemma sequence_length :
   forall {A : Type} lmao (la : list A),

--- a/deps/poulet4/lib/Monads/State.v
+++ b/deps/poulet4/lib/Monads/State.v
@@ -44,5 +44,5 @@ Definition run_with_state
 Definition skip {State Exception: Type}: @state_monad State Exception unit := state_return tt.
 
 
-Hint Unfold state_bind run_with_state state_fail state_return : core.
-Hint Extern 3 => unfold state_bind : core.
+Global Hint Unfold state_bind run_with_state state_fail state_return : core.
+Global Hint Extern 3 => unfold state_bind : core.

--- a/deps/poulet4/lib/P4automata/GeneralBisim.v
+++ b/deps/poulet4/lib/P4automata/GeneralBisim.v
@@ -263,9 +263,9 @@ Module BisimExample.
        d := fun q a => Qaccept |}.
 
   Definition R0 x y := (x = Qaccept <-> y = Qaccept).
-  Hint Unfold R0.
+  Local Hint Unfold R0 : core.
   Definition R x y := (x = Qaccept <-> y = Qaccept) \/ x = Qleft /\ y = Qright.
-  Hint Unfold R.
+  Local Hint Unfold R : core.
   Notation rr := (R0 :: R :: nil).
 
   Lemma prebisim_example:

--- a/deps/poulet4/lib/SimplExpr.v
+++ b/deps/poulet4/lib/SimplExpr.v
@@ -51,7 +51,7 @@ Section Transformer.
   Definition N_to_tempvar (n: N): P4String :=
     P4String.Build_t _ default_tag ("t'" ++ (N_to_string n))%string.
 
-  Eval vm_compute in (N_to_tempvar 123412341234).
+  (* Eval vm_compute in (N_to_tempvar 123412341234).*)
 
   Fixpoint transform_ept (nameIdx: N) (exp: @ExpressionPreT tags_t)
            (tag: tags_t) (typ: @P4Type tags_t) (dir: direction):

--- a/deps/poulet4/lib/ToP4cub.v
+++ b/deps/poulet4/lib/ToP4cub.v
@@ -457,7 +457,6 @@ Section ToP4cub.
     let '(MkExpression _ _ typ _) := e in
     typ.
 
-  (*Print TypBool.*)
   Fixpoint get_string_from_type (t : P4Type) : result (P4String.t tags_t) :=
     match t with
     | TypBool => error "cannot get  from boolean"
@@ -787,8 +786,6 @@ Section ToP4cub.
       error ("[ERROR] Couldnt find label [" ++ P4String.str label ++ "] in enum")
     end.
 
-  Print P4Type.
-
   Definition get_enum_type (expression : @Expression tags_t) : result (list (P4String.t tags_t)) :=
     let '(MkExpression tags pre_expr type dir) := expression in
     match type with
@@ -1114,8 +1111,6 @@ Section ToP4cub.
     let~ inst := translate_instantiation_args params cub_args over "instantiation failed looking up " ++ ctor_name ++ "params: " ++ string_of_nat (List.length params) in
     ok inst.
 
-  (*Print P4Type.*)
-
 
   Definition translate_constructor_parameter (tags : tags_t) (parameter : @P4Parameter tags_t) : result (string * E.ct) :=
     let '(MkParameter opt dir typ default_arg_id var) := parameter in
@@ -1248,7 +1243,6 @@ Section ToP4cub.
 
   Definition translate_actions (actions : list TableActionRef) : result (list string) :=
     List.fold_right translate_actions_loop (ok []) actions.
-  (*Print DeclInstantiation.*)
 
 
   Definition translate_decl_fields (fields : list DeclarationField) : result (F.fs string E.t) :=
@@ -1409,8 +1403,6 @@ Section ToP4cub.
 
   Definition inline_types (decls : DeclCtx) :=
     fold_left (fun acc '(x,t) => subst_type acc x t) (decls.(types)) decls.
-
-  (*Print InferMemberTypes.*)
 
   Definition infer_member_types (decl : DeclCtx) :=
     let infer_ds := List.map InferMemberTypes.inf_d in

--- a/deps/poulet4_Ccomp/_CoqProject
+++ b/deps/poulet4_Ccomp/_CoqProject
@@ -1,2 +1,3 @@
--R lib/ Poulet4_Ccomp
+-Q lib/ Poulet4_Ccomp
+-Q lib/ Poulet4
 lib/Extract.v

--- a/deps/poulet4_Ccomp/lib/Extract.v
+++ b/deps/poulet4_Ccomp/lib/Extract.v
@@ -14,6 +14,8 @@
 (*  INRIA Non-Commercial License Agreement.                            *)
 (*                                                                     *)
 (* *********************************************************************)
+
+Set Warnings "-extraction-reserved-identifier".
 From compcert Require Coqlib.
 From compcert Require Wfsimpl.
 From compcert Require Decidableplus.


### PR DESCRIPTION
Resolved or suppressed warnings relating to extraction:
- `nat` uses `Stdlib` instead of `Pervasives`, b/c [this pull-request is still unresolved](https://github.com/coq/coq/pull/15333).
- Added locality and database info to hints.
- Suppressed "ignored arguments" warning `20`.