### PR TITLE
Poulet4 lvalue

### DIFF
--- a/deps/poulet4/lib/Interpreter.v
+++ b/deps/poulet4/lib/Interpreter.v
@@ -20,7 +20,7 @@ Section Interpreter.
   Notation Val := (@ValueBase bool).
   Notation Sval := (@ValueBase (option bool)).
   Notation ValSet := (@ValueSet tags_t).
-  Notation Lval := (@ValueLvalue tags_t).
+  Notation Lval := ValueLvalue.
 
   Notation ident := string.
   Notation path := (list ident).
@@ -237,8 +237,8 @@ Section Interpreter.
 
   Fixpoint interp_lexpr (this: path) (st: state) (expr: @Expression tags_t) : option (Lval * signal) :=
     match expr with
-    | MkExpression tag (ExpName name loc) typ dir =>
-      Some (MkValueLvalue (ValLeftName name loc) typ, SContinue)
+    | MkExpression tag (ExpName _ loc) typ dir =>
+      Some (ValLeftName loc, SContinue)
     | MkExpression tag (ExpExpressionMember expr name) typ dir =>
       let* (lv, sig) := interp_lexpr this st expr in
       if String.eqb (str name) "next"
@@ -248,16 +248,16 @@ Section Interpreter.
              let ret_sig := if (next <? N.of_nat (List.length headers))%N
                             then sig
                             else SReject "StackOutOfBounds" in
-             Some (MkValueLvalue (ValLeftArrayAccess lv (Z.of_N next)) typ, ret_sig)
+             Some (ValLeftArrayAccess lv (Z.of_N next), ret_sig)
            | _ => None
            end
-      else Some ((MkValueLvalue (ValLeftMember lv (str name)) typ), sig)
+      else Some (ValLeftMember lv (str name), sig)
     | MkExpression tag (ExpBitStringAccess bits lo hi) typ dir =>
       let* (lv, sig) := interp_lexpr this st bits in
       let* bitsv := interp_expr this st bits in
       let* (bitsbl, wn) := sval_to_bits_width bitsv in
       if ((lo <=? hi)%N && (hi <? N.of_nat wn)%N)%bool
-      then Some (MkValueLvalue (ValLeftBitAccess lv hi lo) typ, sig)
+      then Some (ValLeftBitAccess lv hi lo, sig)
       else None
     | MkExpression tag (ExpArrayAccess array idx) typ dir =>
       let* (lv, sig) := interp_lexpr this st array in
@@ -270,19 +270,18 @@ Section Interpreter.
          end in
       let* idxv := interp_expr_det this st idx in
       let* idxz := array_access_idx_to_z idxv in
-      Some (MkValueLvalue (ValLeftArrayAccess lv idxz) typ, sig)
+      Some (ValLeftArrayAccess lv idxz, sig)
     | _ => None
     end.
 
 
   Fixpoint interp_read (st: state) (lv: Lval) : option Sval :=
     match lv with
-    | MkValueLvalue (ValLeftName name loc) typ =>
-      loc_to_sval loc st
-    | MkValueLvalue (ValLeftMember lv fname) typ =>
+    |  ValLeftName loc => loc_to_sval loc st
+    |  ValLeftMember lv fname =>
       let* sv := interp_read st lv in
       find_member sv fname
-    | MkValueLvalue (ValLeftBitAccess lv hi lo) typ =>
+    |  ValLeftBitAccess lv hi lo =>
       let* bitssv := interp_read st lv in
       let* (bitsbl, wn) := sval_to_bits_width bitssv in
       let lonat := N.to_nat lo in
@@ -290,12 +289,11 @@ Section Interpreter.
       if ((lonat <=? hinat)%nat && (hinat <? wn)%nat)%bool
       then Some (ValBaseBit (Ops.bitstring_slice bitsbl lonat hinat))
       else None
-    | MkValueLvalue (ValLeftArrayAccess lv idx) typ =>
+    |  ValLeftArrayAccess lv idx =>
       let* v := interp_read st lv in
       match v with
       | ValBaseStack headers next =>
-        let* rtyp := get_real_type ge typ in
-        let* default_header := uninit_sval_of_typ None rtyp in
+        let* default_header := List.hd_error headers in
         let header := @Znth _ default_header idx headers in
         Some header
       | _ => None
@@ -304,13 +302,13 @@ Section Interpreter.
 
   Fixpoint interp_write (st: state) (lv: Lval) (rhs: Sval) : option state :=
     match lv with
-    | MkValueLvalue (ValLeftName name loc) typ =>
+    |  ValLeftName loc =>
       Some (update_val_by_loc st loc rhs)
-    | MkValueLvalue (ValLeftMember lv fname) typ =>
+    |  ValLeftMember lv fname =>
       let* sv := interp_read st lv in
       let* sv' := set_member sv fname rhs in
       interp_write st lv sv'
-    | MkValueLvalue (ValLeftBitAccess lv hi lo) typ =>
+    |  ValLeftBitAccess lv hi lo =>
       let* sv := interp_read st lv in
       let lonat := N.to_nat lo in
       let hinat := N.to_nat hi in
@@ -331,7 +329,7 @@ Section Interpreter.
         end
       | _ => None
       end
-    | MkValueLvalue (ValLeftArrayAccess lv idx) typ =>
+    |  ValLeftArrayAccess lv idx =>
       let* sv := interp_read st lv in
       match sv with
       | ValBaseStack headers next =>
@@ -477,7 +475,7 @@ Section Interpreter.
                              end
                         else None.
 
-  Definition interp_arg (this: path) (st: state) (exp: option (@Expression tags_t)) (dir: direction) : option ((@argument tags_t) * signal) :=
+  Definition interp_arg (this: path) (st: state) (exp: option (@Expression tags_t)) (dir: direction) : option (argument * signal) :=
     match exp, dir with
     | Some expr, In =>
       let* v := interp_expr_det this st expr in
@@ -599,19 +597,19 @@ Section Interpreter.
              match sig with
              | SReturn v =>
                let* sv := interp_val_sval v in
-               let* st'' := interp_write st' (MkValueLvalue (ValLeftName (BareName name) loc) typ') sv in
+               let* st'' := interp_write st' (ValLeftName loc) sv in
                Some (st'', SContinue)
              | _ => 
                Some (st', sig)
              end
         else let* v := interp_expr_det this st e in
              let* sv := interp_val_sval v in 
-             let* st' := interp_write st (MkValueLvalue (ValLeftName (BareName name) loc) typ') sv in
+             let* st' := interp_write st (ValLeftName loc) sv in
              Some (st', SContinue)
       | MkStatement tags (StatVariable typ' name None loc) typ =>
         let* rtyp := get_real_type ge typ' in
         let* sv := uninit_sval_of_typ (Some false) rtyp in
-        let* st' := interp_write st (MkValueLvalue (ValLeftName (BareName name) loc) typ') sv in
+        let* st' := interp_write st (ValLeftName loc) sv in
         Some (st', SContinue)
       | MkStatement tags (StatConstant typ' name e loc) typ =>
         Some (st, SContinue)

--- a/deps/poulet4/lib/Value.v
+++ b/deps/poulet4/lib/Value.v
@@ -26,6 +26,12 @@ Section Value.
   | ValBaseEnumField (typ_name: string) (enum_name: string)
   | ValBaseSenumField (typ_name: string) (value: (@ValueBase bit)).
 
+  Inductive ValueLvalue :=
+  | ValLeftName (loc: Syntax.Locator)
+  | ValLeftMember (expr: ValueLvalue) (name: string)
+  | ValLeftBitAccess (expr: ValueLvalue) (msb: N) (lsb: N)
+  | ValLeftArrayAccess (expr: ValueLvalue) (idx: Z).
+  
   Context {tags_t : Type}.
 
   Inductive ValueSet:=
@@ -50,14 +56,6 @@ Section Value.
 
   Inductive Env_EvalEnv :=
   | MkEnv_EvalEnv (vs: Env_env ValueLoc) (typ: Env_env (@Typed.P4Type tags_t)) (namespace: string).
-
-  Inductive ValuePreLvalue :=
-  | ValLeftName (name: @Typed.name tags_t) (loc: (Syntax.Locator))
-  | ValLeftMember (expr: ValueLvalue) (name: string)
-  | ValLeftBitAccess (expr: ValueLvalue) (msb: N) (lsb: N)
-  | ValLeftArrayAccess (expr: ValueLvalue) (idx: Z)
-  with ValueLvalue :=
-  | MkValueLvalue (lvalue: ValuePreLvalue) (typ: @Typed.P4Type tags_t).
 
   Inductive ValueFunctionImplementation :=
   | ValFuncImplUser (scope: Env_EvalEnv) (body: (@Syntax.Block tags_t))

--- a/deps/poulet4/lib/ValueUtil.v
+++ b/deps/poulet4/lib/ValueUtil.v
@@ -162,49 +162,6 @@ Section ValueUtil.
         end.
   End ExecValInd.
 
-  Section LvalueInd.
-    Notation LV := (@Value.ValueLvalue tags_t).
-    Notation PLV := (@Value.ValuePreLvalue tags_t).
-
-    Variables (PLval: LV -> Prop).
-    Variables (PPreLval: PLV -> Prop).
-
-    Hypothesis (HMkLval: forall plv typ,
-                   PPreLval plv ->
-                   PLval (Value.MkValueLvalue plv typ)).
-    Hypothesis (HName: forall name loc,
-                   PPreLval (Value.ValLeftName name loc)).
-    Hypothesis (HMember: forall lv fname,
-                   PLval lv ->
-                   PPreLval (Value.ValLeftMember lv fname)).
-    Hypothesis (HBitAccess: forall lv hi lo,
-                   PLval lv ->
-                   PPreLval (Value.ValLeftBitAccess lv hi lo)).
-    Hypothesis (HArrayAccess: forall lv idx,
-                   PLval lv ->
-                   PPreLval (Value.ValLeftArrayAccess lv idx)).
-
-    Hypothesis oops: forall A: Prop, A.
-
-    Fixpoint lvalue_mut_ind (lv: LV) : PLval lv :=
-      match lv with
-      | Value.MkValueLvalue plv _ =>
-        HMkLval _ _ (pre_lvalue_mut_ind plv)
-      end
-    with pre_lvalue_mut_ind (plv: PLV) : PPreLval plv :=
-      match plv with
-      | Value.ValLeftName _ _ =>
-        HName _ _
-      | Value.ValLeftMember lv _ =>
-        HMember _ _ (lvalue_mut_ind lv)
-      | Value.ValLeftBitAccess lv _ _ =>
-        HBitAccess _ _ _ (lvalue_mut_ind lv)
-      | Value.ValLeftArrayAccess lv _ =>
-        HArrayAccess _ _ (lvalue_mut_ind lv)
-      end.
-
-  End LvalueInd.
-
   Definition sval_to_val (read_one_bit : option bool -> bool -> Prop) :=
     exec_val read_one_bit.
 


### PR DESCRIPTION
Cleaner lvalues.

- `ValueLvalue` is no longer a mutually `Inductive` data type.
- `ValueLvalue` no longer has type annotations & thus no longer depends on `tags_t`.
- `ValLeftName` only has a locator now.
- `exec_read_array_access` uses the first header as the default value instead of generating one from a type annotation.
- Analogous updates to `Interpreter.v`.

The build seems to work on my machine.