### PR TITLE
Poulet4 p4light match

### DIFF
--- a/deps/poulet4/lib/P4cub/Semantics/Dynamic/BigStep/Interpreter.v
+++ b/deps/poulet4/lib/P4cub/Semantics/Dynamic/BigStep/Interpreter.v
@@ -269,162 +269,31 @@ Section Parser.
 
   Open Scope pat_scope.
 
-  Definition interpret_pre_match (e : @MatchPreT unit) : option Parser.pat :=
-    match e with
-    | MatchDontCare => mret $ Parser.Wild
-    | MatchMask l1 l2 =>
-        let* (w1, n1) := to_bit =<< interpret_expr [] =<< unembed_expr l1 in
-        let* (w2, n2) := to_bit =<< interpret_expr [] =<< unembed_expr l2 in
-        guard (N.eqb w1 w2) ;;
-        mret $ Parser.Mask (w1 PW n1) (w2 PW n2)
-    | MatchRange l1 l2 =>
-        let* (w1, n1) := to_bit =<< interpret_expr [] =<< unembed_expr l1 in
-        let* (w2, n2) := to_bit =<< interpret_expr [] =<< unembed_expr l2 in
-        guard (N.eqb w1 w2) ;;
-        mret $ Parser.Range (w1 PW n1) (w2 PW n2)
-    | _ => None
-    end.
-
-  Lemma interpret_pre_match_sound :
-    forall e pat, interpret_pre_match e = Some pat -> pre_match_big_step e pat.
-  Proof.
-    intros. destruct e; try discriminate.
-    - inv H. constructor.
-    - inv H. unfold option_bind in *.
-      destruct (unembed_expr expr) eqn:?; try discriminate.
-      destruct (interpret_expr [] e) eqn:?; try discriminate.
-      unfold to_bit in *.
-      destruct v; try discriminate.
-      destruct (unembed_expr mask) eqn:?; try discriminate.
-      destruct (interpret_expr [] e0) eqn:?; try discriminate.
-      destruct v; try discriminate.
-      destruct (width =? width0)%N eqn:?; try discriminate.
-      cbn in *. apply N.eqb_eq in Heqb. subst.
-      inv H1. apply unembed_expr_sound in Heqo, Heqo1.
-      apply interpret_expr_sound in Heqo0, Heqo2. econstructor; eauto.
-    - inv H. unfold option_bind in *.
-      destruct (unembed_expr lo) eqn:?; try discriminate.
-      destruct (interpret_expr [] e) eqn:?; try discriminate.
-      unfold to_bit in *.
-      destruct v; try discriminate.
-      destruct (unembed_expr hi) eqn:?; try discriminate.
-      destruct (interpret_expr [] e0) eqn:?; try discriminate.
-      destruct v; try discriminate.
-      destruct (width =? width0)%N eqn:?; try discriminate.
-      cbn in *. apply N.eqb_eq in Heqb. subst.
-      inv H1. apply unembed_expr_sound in Heqo, Heqo1.
-      apply interpret_expr_sound in Heqo0, Heqo2. econstructor; eauto.
-  Qed.
-
-  Lemma interpret_pre_match_complete :
-    forall e pat, pre_match_big_step e pat -> interpret_pre_match e = Some pat.
-  Proof.
-    intros. inv H.
-    - auto.
-    - apply unembed_expr_complete in H0, H1.
-      apply interpret_expr_complete in H2, H3.
-      cbn. unfold option_bind.
-      destruct (unembed_expr l₁) eqn:?; try discriminate.
-      destruct (unembed_expr l₂) eqn:?; try discriminate.
-      inv H0. inv H1.
-      destruct (interpret_expr [] e₁); try discriminate.
-      destruct (interpret_expr [] e₂); try discriminate.
-      inv H2. inv H3.
-      destruct (to_bit (w) VW (n₁)%value) eqn:?; try discriminate. destruct p.
-      destruct (to_bit (w) VW (n₂)%value) eqn:?; try discriminate. destruct p.
-      cbn in *. inv Heqo1. inv Heqo2.
-      assert ((n0 =? n0)%N = true).
-      { rewrite N.eqb_eq. reflexivity. }
-      replace ((n0 =? n0)%N) with true. cbn. f_equal.
-    - apply unembed_expr_complete in H0, H1.
-      apply interpret_expr_complete in H2, H3.
-      cbn. unfold option_bind.
-      destruct (unembed_expr l₁) eqn:?; try discriminate.
-      destruct (unembed_expr l₂) eqn:?; try discriminate.
-      inv H0. inv H1.
-      destruct (interpret_expr [] e₁); try discriminate.
-      destruct (interpret_expr [] e₂); try discriminate.
-      inv H2. inv H3.
-      destruct (to_bit (w) VW (n₁)%value) eqn:?; try discriminate. destruct p.
-      destruct (to_bit (w) VW (n₂)%value) eqn:?; try discriminate. destruct p.
-      cbn in *. inv Heqo1. inv Heqo2.
-      assert ((n0 =? n0)%N = true).
-      { rewrite N.eqb_eq. reflexivity. }
-      replace ((n0 =? n0)%N) with true. cbn. f_equal.
-  Qed.
-
-  Lemma interpret_pre_match_adequate :
-    forall e pat, interpret_pre_match e = Some pat <-> pre_match_big_step e pat.
-  Proof.
-    split.
-    - apply interpret_pre_match_sound.
-    - apply interpret_pre_match_complete.
-  Qed.
-
-  Close Scope pat_scope.
-
-  Definition interpret_match (e : @Match unit) : option Parser.pat :=
-    let 'MkMatch tt e _ := e in
-    interpret_pre_match e.
-
-  Lemma interpret_match_sound :
-    forall e pat, interpret_match e = Some pat -> match_big_step e pat.
-  Proof.
-    intros. unfold interpret_match in *. destruct e, tags.
-    econstructor. apply interpret_pre_match_sound. assumption.
-  Qed.
-
-  Lemma interpret_match_complete :
-    forall e pat, match_big_step e pat -> interpret_match e = Some pat.
-  Proof.
-    intros. inv H. apply interpret_pre_match_complete in H0. auto.
-  Qed.
-
-  Lemma interpret_match_adequate :
-    forall e pat, interpret_match e = Some pat <-> match_big_step e pat.
-  Proof.
-    split.
-    - apply interpret_match_sound.
-    - apply interpret_match_complete.
-  Qed.
-
-  Definition interpret_table_entry {tags_t : Type} (entry : @table_entry unit tags_t) : option (Parser.pat * action_ref) :=
+  Definition interpret_table_entry {tags_t : Type}
+    (entry : table_entry (tags_t:=tags_t) (Types:=Expr.t) (Expression:=Expr.e) (Pattern:=Parser.pat))
+    : Parser.pat * action_ref :=
     let 'mk_table_entry matches action := entry in
-    let^ patterns := map_monad interpret_match matches in
-    (Parser.Lists patterns, action).
+    (Parser.Lists (map pat_of_match matches), action).
 
   Lemma interpret_table_entry_sound :
-    forall entry pat action,
-      interpret_table_entry entry = Some (pat, action) -> table_entry_big_step entry pat action.
+    forall {tags_t} entry pat action,
+      interpret_table_entry entry = (pat, action) -> table_entry_big_step (tags_t:=tags_t) entry pat action.
   Proof.
     unfold interpret_table_entry. cbn. unfold option_bind.
-    destruct entry. intros. 
-    destruct (map_monad interpret_match matches) eqn:?; try discriminate.
-    inv H. econstructor. generalize dependent matches.
-    induction l; unfold map_monad, "∘" in *; intros.
-    - rewrite sequence_nil in Heqo. apply map_eq_nil in Heqo. subst. constructor.
-    - destruct matches. inv Heqo. cbn in *.
-      unfold option_bind in *. 
-      destruct (interpret_match m) eqn:?; try discriminate.
-      destruct (sequence (map interpret_match matches)) eqn:?; try discriminate.
-      inv Heqo. constructor; auto. apply interpret_match_sound. assumption.
+    destruct entry. intros.
+    inv H. econstructor.
   Qed.
 
   Lemma interpret_table_entry_complete :
-    forall entry pat action,
-      table_entry_big_step entry pat action -> interpret_table_entry entry = Some (pat, action).
+    forall {tags_t} entry pat action,
+      table_entry_big_step entry pat action -> interpret_table_entry (tags_t:=tags_t) entry = (pat, action).
   Proof.
-    intros. inv H. cbn. unfold option_bind. induction H0.
-    - auto.
-    - destruct (map_monad interpret_match l) eqn:?; try discriminate.
-      inv IHForall2. cbn. unfold option_bind. apply interpret_match_complete in H.
-      destruct (interpret_match x); try discriminate. inv H.
-      unfold map_monad, "∘" in *. rewrite Heqo. f_equal.
+    intros. inv H. reflexivity.
   Qed.
 
   Lemma interpret_table_entry_adequate :
-    forall entry pat action,
-      interpret_table_entry entry = Some (pat, action) <-> table_entry_big_step entry pat action.
+    forall {tags_t} entry pat action,
+      interpret_table_entry (tags_t:=tags_t) entry = (pat, action) <-> table_entry_big_step entry pat action.
   Proof.
     split.
     - apply interpret_table_entry_sound.

--- a/deps/poulet4/lib/P4cub/Semantics/Dynamic/BigStep/Properties.v
+++ b/deps/poulet4/lib/P4cub/Semantics/Dynamic/BigStep/Properties.v
@@ -209,7 +209,7 @@ Section Properties.
 
   Lemma lexpr_expr_big_step : forall ϵ e lv v,
       l⟨ ϵ, e ⟩ ⇓ lv -> ⟨ ϵ, e ⟩ ⇓ v -> lv_lookup ϵ lv = Some v.
-  Proof.
+  Proof using.
     intros eps e lv v helv; generalize dependent v.
     induction helv; intros V hv; inv hv; unravel; auto.
     - rewrite (IHhelv _ H4).
@@ -243,12 +243,12 @@ Section Properties.
                          data_args)
                     (map (paramarg_map id (shift_lv c))
                        vdata_args).
-  Proof.
+  Proof using.
     unfold args_big_step, arg_big_step.
     intros.
     destruct c; simpl in *; subst.
-    eapply Forall2_map_l with (lc := data_args).
-    eapply Forall2_map_r with (lc := vdata_args).
+    erewrite Forall2_map_l with (la := data_args).
+    erewrite <- Forall2_map_r with (lc := vdata_args).
     eapply sublist.Forall2_impl; try eassumption.
     intros.
     inversion H; subst; constructor; eauto.
@@ -262,7 +262,7 @@ Section Properties.
       copy_in
         (map (paramarg_map id (shift_lv c)) vargs)
         (us ++ vs ++ eps) = Some eps'.
-  Proof.
+  Proof using.
     intros.
     revert H1.
     unfold copy_in, pipeline.
@@ -270,11 +270,11 @@ Section Properties.
     rewrite !map_map.
     intro.
     apply Forall2_sequence_iff.
-    apply Forall2_map_l with (lc := vargs).
+    rewrite Forall2_map_l with (la := vargs).
     apply Forall2_sequence_iff in H1.
-    apply Forall2_map_l with (lc := vargs) in H1.
+    rewrite Forall2_map_l with (la := vargs) in H1.
     eapply sublist.Forall2_impl; try eassumption.
-    intros.
+    intros. unravel in *.
     destruct a; simpl in *; auto;
       now rewrite shift_lv_lookup.
   Qed.
@@ -286,7 +286,7 @@ Section Properties.
         l = xs ++ ys /\
         length xs = n /\
         length ys = m.
-  Proof.
+  Proof using.
     intros.
     exists (firstn n l).
     exists (skipn n l).
@@ -307,7 +307,7 @@ Section Properties.
       copy_out_argv n (paramarg_map id (shift_lv c) varg)
                eps''
                (us ++ vs ++ eps) = us' ++ vs ++ eps'.
-  Proof.
+  Proof using.
     intros.
     destruct varg as [v | lv | lv]; cbn in *.
     - apply sublist.app_eq_len_eq in H2; eauto.
@@ -333,7 +333,7 @@ Section Properties.
       copy_out n (map (paramarg_map id (shift_lv c)) vargs)
                eps''
                (us ++ vs ++ eps) = us' ++ vs ++ eps'.
-  Proof.
+  Proof using.
     induction vargs; intros.
     - simpl in *.
       apply sublist.app_eq_len_eq in H2; eauto.
@@ -362,7 +362,7 @@ Section Properties.
         (copy_out 0 (map (paramarg_map id (shift_lv c)) vargs)
            eps'' (us ++ vs ++ eps))
       = us' ++ vs ++ eps'.
-  Proof.
+  Proof using.
     unfold lv_update_signal.
     intros.
     destruct olv; simpl in *.
@@ -392,7 +392,7 @@ Section Properties.
     forall vargs l eps,
       copy_in vargs l = Some eps ->
       length eps = length vargs.
-  Proof.
+  Proof using.
     unfold copy_in.
     intros.
     apply Option.sequence_length in H.
@@ -507,7 +507,7 @@ Section Properties.
                           (us ++ vs ++ eps)))
         by eauto using shift_lv_update_signal.
       eapply sbs_action_call; try eassumption.
-      + eapply Forall2_map_l with (lc := ctrl_args).
+      + erewrite Forall2_map_l with (la := ctrl_args).
         eauto using sublist.Forall2_impl, shift_e_eval.
       + eapply shift_args_eval; cbn; auto.
       + (* possible bug with clos *)

--- a/deps/poulet4/lib/P4light/Architecture/Target.v
+++ b/deps/poulet4/lib/P4light/Architecture/Target.v
@@ -6,6 +6,7 @@ Require Import Coq.Lists.List.
 Require Import Coq.Program.Program.
 Require Import Poulet4.P4light.Syntax.Syntax.
 Require Import Poulet4.P4light.Syntax.Value.
+Require Import Poulet4.P4light.Syntax.BigValue.
 From Poulet4.P4light.Syntax Require Import Typed SyntaxUtil P4Int.
 From Poulet4.Utils Require Import Maps AList.
 
@@ -64,43 +65,21 @@ Section Target.
 Context {tags_t: Type}.
 Notation ident := string.
 Notation path := (list ident).
-Notation Val := (@ValueBase bool).
-Notation ValSet := (@ValueSet tags_t).
-
-Fixpoint width_of_val (v: Val): N :=
-  let fix fields_width (fields: StringAList ValueBase) : N :=
-      match fields with
-      | nil => N.of_nat O
-      | (id, v) :: rest => (width_of_val v + fields_width rest)%N
-      end in
-  match v with
-  | ValBaseNull => N.of_nat O
-  | ValBaseBool _ => 1
-  | ValBaseBit bits
-  | ValBaseInt bits
-  | ValBaseVarbit _ bits => Z.to_N (Zlength bits)
-  | ValBaseTuple vs => List.fold_right N.add (0)%N (List.map width_of_val vs)
-  | ValBaseStruct fields
-  | ValBaseHeader fields _ => fields_width fields
-  | ValBaseSenumField _ v => width_of_val v
-  | _ => N.of_nat O
-  end.
 
 (* We want to share the notation of External between P4light and P4cub, so later we need to
   have a parameter `ActionRef`, while `Match` is just shared. *)
 (* Because the entries can refer to constructor parameters, we need to refer the arguments as expressions. *)
 (* Maybe we can just use the definition in Syntax.v. *)
 
-Context {Expression : Type}.
+Context {Types Expression Pattern Val : Type}.
 
 Inductive action_ref :=
   mk_action_ref (action : ident) (args : list (option Expression)).
 
 Inductive table_entry :=
-  (* TODO replace Expression in Match with Val. *)
-  mk_table_entry (matches : list (@Match tags_t)) (action : action_ref).
+  mk_table_entry (matches : list (@Match tags_t Types Pattern)) (action : action_ref).
 
-Definition table_entry_valset : Type :=  ValSet * action_ref.
+Definition table_entry_valset : Type :=  Pattern * action_ref.
 
 Class ExternSem := {
   extern_env_object : Type;
@@ -109,14 +88,14 @@ Class ExternSem := {
   extern_state := PathMap.t extern_object;
   AbsMet := extern_state -> list Val -> extern_state -> list Val -> signal -> Prop;
   (* Allocation should be a function; calling may be fine as a relation. *)
-  construct_extern : extern_env -> extern_state -> ident (* class *) -> list (@P4Type tags_t) -> path
+  construct_extern : extern_env -> extern_state -> ident (* class *) -> list Types -> path
       -> list (path + Val) -> (extern_env * extern_state);
   extern_set_abstract_method : extern_env -> path -> AbsMet -> extern_env;
   exec_extern : extern_env -> extern_state -> ident (* class *) -> ident (* method *) -> path
-      -> list (@P4Type tags_t) -> list Val -> extern_state -> list Val -> signal -> Prop;
+      -> list Types -> list Val -> extern_state -> list Val -> signal -> Prop;
   (* runnable version of exec_extern *)
   interp_extern : extern_env -> extern_state -> ident (* class *) -> ident (* method *) -> path
-      -> list (@P4Type tags_t) -> list Val -> Result.result Exn.t (extern_state * list Val * signal);
+      -> list Types -> list Val -> Result.result Exn.t (extern_state * list Val * signal);
   interp_extern_safe :
     forall env st class method this targs args st' retvs sig,
       interp_extern env st class method this targs args = Result.Ok (st', retvs, sig) ->
@@ -131,8 +110,8 @@ Class SeparableExternSem := {
   (* extern_state := @IdentMap.t tags_t extern_object; *)
   (* extern_empty : extern_state := IdentMap.empty; *)
   (* Allocation should be a function; calling may be fine as a relation. *)
-  ses_alloc_extern : ident (* class *) -> list (@P4Type tags_t) -> list Val -> ses_extern_object;
-  ses_exec_extern : ident (* class *) -> ident (* method *) -> ses_extern_object -> list (@P4Type tags_t) -> list Val -> ses_extern_object -> list Val -> signal -> Prop;
+  ses_alloc_extern : ident (* class *) -> list Types -> list Val -> ses_extern_object;
+  ses_exec_extern : ident (* class *) -> ident (* method *) -> ses_extern_object -> list Types -> list Val -> ses_extern_object -> list Val -> signal -> Prop;
   (* ses_extern_get_entries : extern_state -> path -> list table_entry; *)
   ses_extern_match : list (Val * ident (* match_kind *)) -> list table_entry_valset -> option action_ref (* action *)
 }.
@@ -142,7 +121,7 @@ Context (ses : SeparableExternSem).
 
 (* Definition extern_state' : Type := @PathMap.t tags_t ses_extern_object * @PathMap.t tags_t (list table_entry).
 
-Inductive exec_extern' : extern_state' -> ident (* class *) -> ident (* method *) -> path -> list (@P4Type tags_t) -> list Val -> extern_state' -> list Val -> signal -> Prop :=
+Inductive exec_extern' : extern_state' -> ident (* class *) -> ident (* method *) -> path -> list Types -> list Val -> extern_state' -> list Val -> signal -> Prop :=
   | exec_extern_intro : forall s class method targs p args s' args' vret obj obj',
       PathMap.get p (fst s) = Some obj ->
       ses_exec_extern class method obj targs args obj' args' vret ->
@@ -171,14 +150,14 @@ End ExternSemOfSeparableExternSem. *)
 Class Target := {
   extern_sem :> ExternSem;
     target_main_name: string;
-    exec_prog : list (@P4Type tags_t) ->
+    exec_prog : list Types ->
                 (path -> extern_state -> list Val -> extern_state -> list Val -> signal -> Prop) ->
                 extern_state ->
                 list bool ->
                 extern_state ->
                 list bool ->
                 Prop;
-    interp_prog : list (@P4Type tags_t) ->
+    interp_prog : list Types ->
                   (path -> extern_state -> list Val -> Result.result Exn.t (extern_state * list Val * signal)) ->
       extern_state -> Z -> list bool -> Result.result Exn.t (extern_state * Z * list bool);
 }.

--- a/deps/poulet4/lib/P4light/Architecture/Target.v
+++ b/deps/poulet4/lib/P4light/Architecture/Target.v
@@ -71,7 +71,7 @@ Notation path := (list ident).
 (* Because the entries can refer to constructor parameters, we need to refer the arguments as expressions. *)
 (* Maybe we can just use the definition in Syntax.v. *)
 
-Context {Types Expression Pattern Val : Type}.
+Context {Types Expression Pattern Val Signal : Type}.
 
 Inductive action_ref :=
   mk_action_ref (action : ident) (args : list (option Expression)).
@@ -86,16 +86,16 @@ Class ExternSem := {
   extern_env := PathMap.t extern_env_object;
   extern_object : Type;
   extern_state := PathMap.t extern_object;
-  AbsMet := extern_state -> list Val -> extern_state -> list Val -> signal -> Prop;
+  AbsMet := extern_state -> list Val -> extern_state -> list Val -> Signal -> Prop;
   (* Allocation should be a function; calling may be fine as a relation. *)
   construct_extern : extern_env -> extern_state -> ident (* class *) -> list Types -> path
       -> list (path + Val) -> (extern_env * extern_state);
   extern_set_abstract_method : extern_env -> path -> AbsMet -> extern_env;
   exec_extern : extern_env -> extern_state -> ident (* class *) -> ident (* method *) -> path
-      -> list Types -> list Val -> extern_state -> list Val -> signal -> Prop;
+      -> list Types -> list Val -> extern_state -> list Val -> Signal -> Prop;
   (* runnable version of exec_extern *)
   interp_extern : extern_env -> extern_state -> ident (* class *) -> ident (* method *) -> path
-      -> list Types -> list Val -> Result.result Exn.t (extern_state * list Val * signal);
+      -> list Types -> list Val -> Result.result Exn.t (extern_state * list Val * Signal);
   interp_extern_safe :
     forall env st class method this targs args st' retvs sig,
       interp_extern env st class method this targs args = Result.Ok (st', retvs, sig) ->
@@ -111,7 +111,7 @@ Class SeparableExternSem := {
   (* extern_empty : extern_state := IdentMap.empty; *)
   (* Allocation should be a function; calling may be fine as a relation. *)
   ses_alloc_extern : ident (* class *) -> list Types -> list Val -> ses_extern_object;
-  ses_exec_extern : ident (* class *) -> ident (* method *) -> ses_extern_object -> list Types -> list Val -> ses_extern_object -> list Val -> signal -> Prop;
+  ses_exec_extern : ident (* class *) -> ident (* method *) -> ses_extern_object -> list Types -> list Val -> ses_extern_object -> list Val -> Signal -> Prop;
   (* ses_extern_get_entries : extern_state -> path -> list table_entry; *)
   ses_extern_match : list (Val * ident (* match_kind *)) -> list table_entry_valset -> option action_ref (* action *)
 }.
@@ -121,7 +121,7 @@ Context (ses : SeparableExternSem).
 
 (* Definition extern_state' : Type := @PathMap.t tags_t ses_extern_object * @PathMap.t tags_t (list table_entry).
 
-Inductive exec_extern' : extern_state' -> ident (* class *) -> ident (* method *) -> path -> list Types -> list Val -> extern_state' -> list Val -> signal -> Prop :=
+Inductive exec_extern' : extern_state' -> ident (* class *) -> ident (* method *) -> path -> list Types -> list Val -> extern_state' -> list Val -> Signal -> Prop :=
   | exec_extern_intro : forall s class method targs p args s' args' vret obj obj',
       PathMap.get p (fst s) = Some obj ->
       ses_exec_extern class method obj targs args obj' args' vret ->
@@ -151,14 +151,14 @@ Class Target := {
   extern_sem :> ExternSem;
     target_main_name: string;
     exec_prog : list Types ->
-                (path -> extern_state -> list Val -> extern_state -> list Val -> signal -> Prop) ->
+                (path -> extern_state -> list Val -> extern_state -> list Val -> Signal -> Prop) ->
                 extern_state ->
                 list bool ->
                 extern_state ->
                 list bool ->
                 Prop;
     interp_prog : list Types ->
-                  (path -> extern_state -> list Val -> Result.result Exn.t (extern_state * list Val * signal)) ->
+                  (path -> extern_state -> list Val -> Result.result Exn.t (extern_state * list Val * Signal)) ->
       extern_state -> Z -> list bool -> Result.result Exn.t (extern_state * Z * list bool);
 }.
 

--- a/deps/poulet4/lib/P4light/Architecture/Tofino.v
+++ b/deps/poulet4/lib/P4light/Architecture/Tofino.v
@@ -7,6 +7,7 @@ Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Require Import Coq.Program.Program.
 Require Import Poulet4.P4light.Syntax.Value.
+Require Import Poulet4.P4light.Syntax.BigValue.
 Require Import Poulet4.P4light.Syntax.ValueUtil.
 Require Import Poulet4.P4light.Syntax.Syntax.
 From Poulet4.P4light.Syntax Require Import
@@ -384,7 +385,7 @@ Inductive ValSetT :=
 | VSTRange (lo: Val) (hi: Val)
 | VSTProd (_: list ValSetT)
 | VSTLpm (nbits: N) (value: Val)
-| VSTValueSet (size: N) (members: list (list (@Match tags_t))) (sets: list ValSetT).
+| VSTValueSet (size: N) (members: list (list (@Match tags_t P4Type ValSetT))) (sets: list ValSetT).
 
 Fixpoint valset_to_valsett (vs : ValSet) :=
   match vs with
@@ -394,7 +395,11 @@ Fixpoint valset_to_valsett (vs : ValSet) :=
   | ValSetRange lo hi => VSTRange lo hi
   | ValSetProd sets => VSTProd (List.map valset_to_valsett sets)
   | ValSetLpm nbits value => VSTLpm nbits value
-  | ValSetValueSet size members sets => VSTValueSet size members (List.map valset_to_valsett sets)
+  | ValSetValueSet size members sets =>
+      VSTValueSet
+        size
+        (List.map (List.map (map_Match id valset_to_valsett)) members)
+        (List.map valset_to_valsett sets)
   end.
 
 Definition extern_get_entries (es : extern_state) (p : path) : list table_entry :=

--- a/deps/poulet4/lib/P4light/Architecture/Tofino.v
+++ b/deps/poulet4/lib/P4light/Architecture/Tofino.v
@@ -29,8 +29,8 @@ Notation ident := string.
 Notation path := (list ident).
 Notation P4Type := (@P4Type tags_t).
 Notation Val := (@ValueBase bool).
-Notation ValSet := ValueSet.
-Notation table_entry := (@table_entry tags_t Expression).
+Notation ValSet := (@ValueSet tags_t).
+Notation table_entry := (@table_entry tags_t P4Type Expression ValSet).
 Notation action_ref := (@action_ref Expression).
 
 Global Instance Inhabitant_Val : Inhabitant Val := ValBaseNull.

--- a/deps/poulet4/lib/P4light/Architecture/V1ModelTarget.v
+++ b/deps/poulet4/lib/P4light/Architecture/V1ModelTarget.v
@@ -6,6 +6,7 @@ Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Require Import Coq.Program.Program.
 Require Import Poulet4.P4light.Syntax.Value.
+Require Import Poulet4.P4light.Syntax.BigValue.
 Require Import Poulet4.P4light.Syntax.Syntax.
 Require Poulet4.P4light.Semantics.Extract.
 From Poulet4.P4light.Syntax Require Import
@@ -355,7 +356,7 @@ Inductive ValSetT :=
 | VSTRange (lo: Val) (hi: Val)
 | VSTProd (_: list ValSetT)
 | VSTLpm (nbits: N) (value: Val)
-| VSTValueSet (size: N) (members: list (list (@Match tags_t))) (sets: list ValSetT).
+| VSTValueSet (size: N) (members: list (list (@Match tags_t P4Type ValSetT))) (sets: list ValSetT).
 
 Fixpoint valset_to_valsett (vs : ValSet) :=
   match vs with
@@ -365,7 +366,11 @@ Fixpoint valset_to_valsett (vs : ValSet) :=
   | ValSetRange lo hi => VSTMask lo hi
   | ValSetProd sets => VSTProd (List.map valset_to_valsett sets)
   | ValSetLpm nbits value => VSTLpm nbits value
-  | ValSetValueSet size members sets => VSTValueSet size members (List.map valset_to_valsett sets)
+  | ValSetValueSet size members sets =>
+      VSTValueSet
+        size
+        (List.map (List.map (map_Match id valset_to_valsett)) members)
+        (List.map valset_to_valsett sets)
   end.
 
 Definition extern_get_entries (es : extern_state) (p : path) : list table_entry :=

--- a/deps/poulet4/lib/P4light/Architecture/V1ModelTarget.v
+++ b/deps/poulet4/lib/P4light/Architecture/V1ModelTarget.v
@@ -27,8 +27,8 @@ Notation ident := string.
 Notation path := (list ident).
 Notation P4Type := (@P4Type tags_t).
 Notation Val := (@ValueBase bool).
-Notation ValSet := ValueSet.
-Notation table_entry := (@table_entry tags_t Expression).
+Notation ValSet := (@ValueSet tags_t).
+Notation table_entry := (@table_entry tags_t P4Type Expression ValSet).
 Notation action_ref := (@action_ref Expression).
 
 Global Instance Inhabitant_Val : Inhabitant Val := ValBaseNull.

--- a/deps/poulet4/lib/P4light/Semantics/Semantics.v
+++ b/deps/poulet4/lib/P4light/Semantics/Semantics.v
@@ -317,7 +317,7 @@ Definition eval_p4int_val (n: P4Int) : Val :=
   | Some (w, false) => ValBaseBit (to_lbool w (P4Int.value n))
   end.
 
-Context {target : @Target tags_t (@P4Type tags_t) (@Expression tags_t) (@ValueSet tags_t) Val}.
+Context {target : @Target tags_t (@P4Type tags_t) (@Expression tags_t) (@ValueSet tags_t) Val signal}.
 
 Definition state : Type := mem * extern_state.
 
@@ -651,14 +651,14 @@ Inductive exec_match (read_one_bit : option bool -> bool -> Prop) :
                      path -> @Match tags_t (@P4Type tags_t) ValSet -> ValSet -> Prop :=
   | exec_match_dont_care : forall this tag typ,
       exec_match read_one_bit this (MkMatch tag MatchDontCare typ) ValSetUniversal
-  | exec_match_mask : forall expr exprv mask maskv this tag typ,
+  | exec_match_mask : forall expr mask this tag typ,
                       exec_match read_one_bit this
                       (MkMatch tag (MatchMask expr mask) typ)
-                      (ValSetMask exprv maskv)
-  | exec_match_range : forall lo lov hi hiv this tag typ,
+                      (ValSetMask expr mask)
+  | exec_match_range : forall lo hi this tag typ,
                         exec_match read_one_bit this
                         (MkMatch tag (MatchRange lo hi) typ)
-                        (ValSetRange lov hiv)
+                        (ValSetRange lo hi)
   | exec_match_cast : forall newtyp expr oldv newv this tag typ real_typ,
                       get_real_type (ge_typ ge) newtyp = Some real_typ ->
                       Ops.eval_cast_set real_typ oldv = Some newv ->

--- a/deps/poulet4/lib/P4light/Semantics/Semantics.v
+++ b/deps/poulet4/lib/P4light/Semantics/Semantics.v
@@ -127,7 +127,7 @@ Variant fundef :=
       (keys : list (@TableKey tags_t))
       (actions : list (@Expression tags_t))
       (default_action : @Expression tags_t)
-      (entries : option (list (@table_entry tags_t (@Expression tags_t))))
+      (entries : option (list (@table_entry tags_t (@P4Type tags_t) (@Expression tags_t) (@ValueSet tags_t))))
   | FExternal
       (class : ident)
       (name : ident).
@@ -317,7 +317,7 @@ Definition eval_p4int_val (n: P4Int) : Val :=
   | Some (w, false) => ValBaseBit (to_lbool w (P4Int.value n))
   end.
 
-Context {target : @Target tags_t (@Expression tags_t)}.
+Context {target : @Target tags_t (@P4Type tags_t) (@Expression tags_t) (@ValueSet tags_t) Val}.
 
 Definition state : Type := mem * extern_state.
 
@@ -670,8 +670,8 @@ Definition exec_matches (read_one_bit : option bool -> bool -> Prop) (this : pat
   Forall2 (exec_match read_one_bit this).
 
 Inductive exec_table_entry (read_one_bit : option bool -> bool -> Prop) :
-                           path -> @table_entry tags_t ValueSet ->
-                           (@table_entry_valset tags_t ValueSet) -> Prop :=
+                           path -> @table_entry tags_t (@P4Type tags_t) (@Expression tags_t) ValueSet ->
+                           (@table_entry_valset (@Expression tags_t) ValueSet) -> Prop :=
   | exec_table_entry_intro : forall this ms svs action entryvs,
                              exec_matches read_one_bit this ms svs ->
                              (if (List.length svs =? 1)%nat

--- a/deps/poulet4/lib/P4light/Syntax/BigValue.v
+++ b/deps/poulet4/lib/P4light/Syntax/BigValue.v
@@ -1,0 +1,77 @@
+From Coq Require Import Strings.String ZArith.BinInt.
+From Poulet4 Require Import Utils.AList.
+Require Import Poulet4.P4light.Syntax.Syntax.
+Require Export Poulet4.P4light.Syntax.Value.
+
+Section Value.
+
+  Inductive signal : Type :=
+ | SContinue : signal
+ | SReturn : (@ValueBase bool) -> signal
+ | SExit
+ (* parser's states include accept and reject *)
+ | SReject : string -> signal.
+
+  Definition SReturnNull := SReturn ValBaseNull.
+
+  Inductive ValueLvalue :=
+  | ValLeftName (loc: Syntax.Locator)
+  | ValLeftMember (expr: ValueLvalue) (name: string)
+  | ValLeftBitAccess (expr: ValueLvalue) (msb: N) (lsb: N)
+  | ValLeftArrayAccess (expr: ValueLvalue) (idx: Z).
+
+  Context {tags_t : Type}.
+
+  Definition ValueLoc := string.
+
+  Inductive ValueTable :=
+  | MkValTable (name: string) (keys: list (@Syntax.TableKey tags_t))
+               (actions: list (@Syntax.TableActionRef tags_t))
+               (default_action: @Syntax.TableActionRef tags_t)
+               (const_entries: list (@Syntax.TableEntry tags_t)).
+
+
+  Definition Env_env binding := list (StringAList binding).
+
+  Inductive Env_EvalEnv :=
+  | MkEnv_EvalEnv (vs: Env_env ValueLoc) (typ: Env_env (@Typed.P4Type tags_t)) (namespace: string).
+
+  Inductive ValueFunctionImplementation :=
+  | ValFuncImplUser (scope: Env_EvalEnv) (body: (@Syntax.Block tags_t))
+  | ValFuncImplExtern (name: string) (caller: option (ValueLoc * string))
+  | ValFuncImplBuiltin (name: string) (caller: ValueLvalue).
+
+  Inductive ValueObject :=
+  | ValObjParser (scope: Env_EvalEnv)
+                 (constructor_params: list (@Typed.P4Parameter tags_t))
+                 (params: list (@Typed.P4Parameter tags_t)) (locals: list (@Syntax.Declaration tags_t))
+                 (states: list (@Syntax.ParserState tags_t))
+  | ValObjTable (_: ValueTable)
+  | ValObjControl (scope: Env_EvalEnv)
+                  (constructor_params: list (@Typed.P4Parameter tags_t))
+                  (params: list (@Typed.P4Parameter tags_t)) (locals: list (@Syntax.Declaration tags_t))
+                  (apply: (@Syntax.Block tags_t))
+  | ValObjPackage (args: StringAList ValueLoc)
+  | ValObjRuntime (loc: ValueLoc) (obj_name: string)
+  | ValObjFun (params: list (@Typed.P4Parameter tags_t)) (impl: ValueFunctionImplementation)
+  | ValObjAction (scope: Env_EvalEnv) (params: list (@Typed.P4Parameter tags_t))
+                 (body: (@Syntax.Block tags_t))
+  | ValObjPacket (bits: list bool).
+
+  Inductive ValueConstructor :=
+  | ValConsParser (scope: Env_EvalEnv) (constructor_params: list (@Typed.P4Parameter tags_t))
+                  (params: list (@Typed.P4Parameter tags_t)) (locals: list (@Syntax.Declaration tags_t))
+                  (states: list (@Syntax.ParserState tags_t))
+  | ValConsTable (_: ValueTable)
+  | ValConsControl (scope: Env_EvalEnv) (constructor_params: list (@Typed.P4Parameter tags_t))
+                   (params: list (@Typed.P4Parameter tags_t)) (locals: list (@Syntax.Declaration tags_t))
+                   (apply: (@Syntax.Block tags_t))
+  | ValConsPackage (params: list (@Typed.P4Parameter tags_t)) (args: StringAList ValueLoc)
+  | ValConsExternObj (_: StringAList (list (@Typed.P4Parameter tags_t))).
+
+  Inductive Value (bit : Type) :=
+  | ValBase (_: @ValueBase bit)
+  | ValObj (_: ValueObject)
+  | ValCons (_: ValueConstructor).
+
+End Value.

--- a/deps/poulet4/lib/P4light/Syntax/Syntax.v
+++ b/deps/poulet4/lib/P4light/Syntax/Syntax.v
@@ -177,6 +177,9 @@ Section Syntax.
   | InitInstantiation (tags: tags_t)  (typ: @P4Type tags_t)
                       (args: list Expression) (name: P4String) (init: list Initializer).
 
+  Definition ExpressionPreT_of_Expression
+    '(MkExpression _ e _ _ : Expression) : ExpressionPreT := e.
+  
   Section MatchMap.
     Context {A B U V : Type}.
     Variable f : A -> B.

--- a/deps/poulet4/lib/P4light/Transformations/GenLoc.v
+++ b/deps/poulet4/lib/P4light/Transformations/GenLoc.v
@@ -294,7 +294,9 @@ Section Transformer.
       MkTableActionRef tags action' typ
     end.
 
-  Definition transform_match (e: env) (mt: @Match tags_t): @Match tags_t :=
+  Definition transform_match
+    (e: env)
+    (mt: @Match tags_t (@P4Type tags_t) (@Expression tags_t)): @Match tags_t P4Type Expression :=
     match mt with
     | MkMatch tags expr typ =>
       match expr with
@@ -313,20 +315,12 @@ Section Transformer.
       end
     end.
 
-  Definition transform_psrcase (e: env) (pc: @ParserCase tags_t): @ParserCase tags_t :=
-    match pc with
-    | MkParserCase tags matches next =>
-      let matches' := map (transform_match e) matches in
-      MkParserCase tags matches next
-    end.
-
   Definition transform_psrtrans (e: env) (pt: @ParserTransition tags_t): @ParserTransition tags_t :=
     match pt with
     | ParserDirect _ _ => pt
     | ParserSelect tags exprs cases =>
       let exprs' := transform_exprs e exprs in
-      let cases' := map (transform_psrcase e) cases in
-      ParserSelect tags exprs' cases'
+      ParserSelect tags exprs' cases
     end.
 
   Definition transform_psrst (e: env) (ps: @ParserState tags_t): monad (@ParserState tags_t) :=
@@ -341,9 +335,8 @@ Section Transformer.
   Definition transform_tblenty (e: env) (te: @TableEntry tags_t): @TableEntry tags_t :=
     match te with
     | MkTableEntry tags matches action =>
-      let matches' := map (transform_match e) matches in
       let action' := transform_tar e action in
-      MkTableEntry tags matches' action'
+      MkTableEntry tags matches action'
     end.
 
   Definition transform_tblprop (e: env) (tp: @TableProperty tags_t): @TableProperty tags_t :=

--- a/deps/poulet4/lib/P4light/Transformations/InlineConstants.v
+++ b/deps/poulet4/lib/P4light/Transformations/InlineConstants.v
@@ -80,38 +80,13 @@ Section InlineConstants.
     Definition subst_exprs : list (@Expression tags_t) -> list (@Expression tags_t) :=
       List.map subst_expr.
 
-    (** Maps [subst_expr] over a [MatchPreT] *)
-    Definition subst_match_pre (match_pre : @MatchPreT tags_t) :  @MatchPreT tags_t :=
-      match match_pre with
-      | MatchDontCare => MatchDontCare
-      | MatchMask e mask => MatchMask (subst_expr e) (subst_expr mask)
-      | MatchRange lo hi => MatchRange (subst_expr lo) (subst_expr hi)
-      | MatchCast type expr => MatchCast type (subst_expr expr)
-      end.
-
-    (** Maps [subst_expr] over a [Match] *)
-    Definition subst_match (mtch : @Match tags_t) : @Match tags_t :=
-      let 'MkMatch tags e type := mtch in
-      MkMatch tags (subst_match_pre e) type.
-
-    (** Maps [subst_expr] over a list of [Match]es *)
-    Definition subst_matches : list (@Match tags_t) -> list (@Match tags_t) := 
-      List.map subst_match.
-
-    (** Maps [subst_expr] over a [ParserCase] *)
-    Definition subst_parser_case (case : @ParserCase tags_t) : @ParserCase tags_t :=
-      let 'MkParserCase tags matches next := case in
-      let matches' := subst_matches matches in
-      MkParserCase tags matches' next.
-
     (** Maps [subst_expr] over a [ParserTransition] *)
     Definition subst_parser_transition (trans : @ParserTransition tags_t) : @ParserTransition tags_t :=
       match trans with
       | ParserDirect _ _ => trans
       | ParserSelect tags es cases =>
         let es' := subst_exprs es in
-        let cases' := List.map subst_parser_case cases in
-        ParserSelect tags es' cases'
+        ParserSelect tags es' cases
       end.
 
     (** [subst_method_call fn types args] maps [subst_expr] over
@@ -171,9 +146,8 @@ Section InlineConstants.
         over [MkTableEntry tags matches action] *)
     Definition subst_table_entry entry :=
       let 'MkTableEntry tags matches action := entry in
-      let matches' := subst_matches matches in
       let action' := subst_table_action_ref action in
-      MkTableEntry tags matches' action'.
+      MkTableEntry tags matches action'.
 
     (** [subst_table_property (MkTableProperty tags const name value)] maps
         [subst_expr] over [MkTableProperty tags const name value] *)


### PR DESCRIPTION
In progress pull request for p4light `Match`, `MatchPreT`, and `ValueSet`.

These changes are to make `Match` and `MatchPreT` use `ValueSet` instead of `Expression`.

`Match` and `MatchPreT` are parameterized by the data type for p4 types and value sets/patterns. In p4light syntax and semantics this is always instantiated with `P4Type` and `ValueSet`. This is to enable a broader interface for `Target.v` that does not rely upon p4light data types.

I'm currently stuck refactoring `exec_match` in `Semantics.v`. `Match` uses `ValueSet` for mask and range operands but `ValueSet` uses`ValueBase` for mask and range operands. `Match` used to use `Expression` and evaluate the expressions to values for this but in changing it to `ValueSet` it's not as straightforward to "evaluate" a `ValueSet` to a value. Should `ValueSet` use `ValueSet` for mask and range?