### PR TITLE
no match in valset

### DIFF
--- a/coq/lib/Monads/Monad.v
+++ b/coq/lib/Monads/Monad.v
@@ -58,6 +58,19 @@ Fixpoint asequence {K A} {m: Type -> Type} {M : Monad m} (acts: list (K * m A)) 
       mret ((k, t) :: rest)
   end.
 
+Definition fold_left_monad
+  {A B : Type} {m : Type -> Type} {M : Monad m}
+  (f : A -> B -> m A) (l : list B) (a : A) : m A :=
+  List.fold_left
+    (fun ma b => let* a := ma in f a b)
+    l (mret a).
+
+Definition fold_right_monad
+  {A B : Type} {m : Type -> Type} {M : Monad m}
+  (f : B -> A -> m A) (a : A) : list B -> m A :=
+  List.fold_right
+    (fun b ma => ma >>= f b) (mret a).
+
 Definition map_monad {A B : Type} {m : Type -> Type} {M : Monad m} (f : A -> m B) : list A -> m (list B) :=
   compose sequence (List.map f).
 
@@ -97,3 +110,11 @@ Notation "'let^' ' x ':=' c1 'in' c2" := (@lift_monad _ _ _ _ (fun x => c2) c1)
     format "'let^'  ' x  ':='  c1  'in' '//' c2", c1 at next level, 
     right associativity
   ) : monad_scope.
+
+Definition opt_sequence
+  {A} {m : Type -> Type} `{M : Monad m}
+  (o : option (list (m A))) : m (option (list A)) :=
+  match o with
+  | Some l => sequence l >>| Some
+  | None   => mret None
+  end.

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Semantics.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Semantics.v
@@ -192,35 +192,10 @@ Definition lv_update_signal
 
 Notation light_set := (@ValueSet unit).
 
-Open Scope pat_scope.
-
-(* TODO: cast case. *)
-Variant pre_match_big_step : @MatchPreT unit -> Parser.pat -> Prop :=
-  | bs_DontCare :
-    pre_match_big_step MatchDontCare Parser.Wild
-  | bs_Mask l₁ l₂ e₁ e₂ n₁ n₂ w :
-    embed_expr e₁ l₁ ->
-    embed_expr e₂ l₂ ->
-    ⟨ [], e₁ ⟩ ⇓ w VW n₁ ->
-    ⟨ [], e₂ ⟩ ⇓ w VW n₂ ->
-    pre_match_big_step (MatchMask l₁ l₂) (Parser.Mask (w PW n₁) (w PW n₂))
-  | bs_Range l₁ l₂ e₁ e₂ n₁ n₂ w :
-    embed_expr e₁ l₁ ->
-    embed_expr e₂ l₂ ->
-    ⟨ [], e₁ ⟩ ⇓ w VW n₁ ->
-    ⟨ [], e₂ ⟩ ⇓ w VW n₂ ->
-    pre_match_big_step (MatchRange l₁ l₂) (Parser.Range (w PW n₁) (w PW n₂)).
-
-Close Scope pat_scope.
-
-Variant match_big_step : @Match unit -> Parser.pat -> Prop :=
-  | bs_MkMatch τ m p :
-    pre_match_big_step m p -> match_big_step (MkMatch tt m τ) p.
-
 Variant table_entry_big_step
-  : table_entry (tags_t:=unit) (Expression:=Expr.e) -> Parser.pat -> action_ref -> Prop :=
+  : table_entry (Expression:=Expr.e) -> Parser.pat -> action_ref -> Prop :=
   | bs_mk_table_entry mtchs pats aref :
-    Forall2 match_big_step mtchs pats ->
+    Forall2 embed_pat_valset pats mtchs ->
     table_entry_big_step (mk_table_entry mtchs aref) (Parser.Lists pats) aref.
 
 Notation Extern_Sem := (ExternSem (tags_t:=unit) (Expression:=Expr.e)).

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Value/Embed.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Value/Embed.v
@@ -286,7 +286,7 @@ Section Embed.
     - apply unembed_expr_complete.
   Qed.
 
-  Inductive embed_pat_valset : Parser.pat -> ValueSet (tags_t:=tags_t) -> Prop :=
+  Inductive embed_pat_valset : Parser.pat -> ValueSet -> Prop :=
   | embed_pat_wild :
     embed_pat_valset Parser.Wild ValSetUniversal
   | embed_pat_bit w n :

--- a/coq/lib/P4light/Architecture/Target.v
+++ b/coq/lib/P4light/Architecture/Target.v
@@ -96,7 +96,6 @@ Inductive action_ref :=
   mk_action_ref (action : ident) (args : list (option Expression)).
 
 Inductive table_entry :=
-  (* TODO replace Expression in Match with Val. *)
   mk_table_entry (matches : list ValueSet) (action : action_ref).
 
 Definition table_entry_valset : Type :=  ValueSet * action_ref.

--- a/coq/lib/P4light/Architecture/Target.v
+++ b/coq/lib/P4light/Architecture/Target.v
@@ -65,7 +65,6 @@ Context {tags_t: Type}.
 Notation ident := string.
 Notation path := (list ident).
 Notation Val := (@ValueBase bool).
-Notation ValSet := (@ValueSet tags_t).
 
 Fixpoint width_of_val (v: Val): N :=
   let fix fields_width (fields: StringAList ValueBase) : N :=
@@ -98,9 +97,9 @@ Inductive action_ref :=
 
 Inductive table_entry :=
   (* TODO replace Expression in Match with Val. *)
-  mk_table_entry (matches : list (@Match tags_t)) (action : action_ref).
+  mk_table_entry (matches : list ValueSet) (action : action_ref).
 
-Definition table_entry_valset : Type :=  ValSet * action_ref.
+Definition table_entry_valset : Type :=  ValueSet * action_ref.
 
 Class ExternSem := {
   extern_env_object : Type;

--- a/coq/lib/P4light/Architecture/V1ModelTarget.v
+++ b/coq/lib/P4light/Architecture/V1ModelTarget.v
@@ -27,7 +27,7 @@ Notation path := (list ident).
 Notation P4Type := (@P4Type tags_t).
 Notation Val := (@ValueBase bool).
 Notation ValSet := ValueSet.
-Notation table_entry := (@table_entry tags_t Expression).
+Notation table_entry := (@table_entry Expression).
 Notation action_ref := (@action_ref Expression).
 
 Global Instance Inhabitant_Val : Inhabitant Val := ValBaseNull.
@@ -355,7 +355,7 @@ Inductive ValSetT :=
 | VSTRange (lo: Val) (hi: Val)
 | VSTProd (_: list ValSetT)
 | VSTLpm (nbits: N) (value: Val)
-| VSTValueSet (size: N) (members: list (list (@Match tags_t))) (sets: list ValSetT).
+| VSTValueSet (size: N) (members: list (list ValSetT)) (sets: list ValSetT).
 
 Fixpoint valset_to_valsett (vs : ValSet) :=
   match vs with
@@ -365,7 +365,11 @@ Fixpoint valset_to_valsett (vs : ValSet) :=
   | ValSetRange lo hi => VSTMask lo hi
   | ValSetProd sets => VSTProd (List.map valset_to_valsett sets)
   | ValSetLpm nbits value => VSTLpm nbits value
-  | ValSetValueSet size members sets => VSTValueSet size members (List.map valset_to_valsett sets)
+  | ValSetValueSet size members sets =>
+      VSTValueSet
+        size
+        (List.map (List.map valset_to_valsett) members)
+        (List.map valset_to_valsett sets)
   end.
 
 Definition extern_get_entries (es : extern_state) (p : path) : list table_entry :=

--- a/coq/lib/P4light/Semantics/InterpreterSafe.v
+++ b/coq/lib/P4light/Semantics/InterpreterSafe.v
@@ -777,49 +777,6 @@ Section InterpreterSafe.
         eapply sval_to_val_interp.
   Qed.
 
-  Lemma interp_match_safe:
-    forall this m vset,
-      Interpreter.interp_match ge this m = Ok vset ->
-      Semantics.exec_match ge read_ndetbit this m vset.
-  Proof.
-    destruct m.
-    intros.
-    simpl in *.
-    destruct expr.
-    - inversion H.
-      constructor.
-    - repeat simpl_result_all.
-      repeat simpl_result_all.
-      inversion H; subst.
-      constructor; eauto using interp_expr_det_safe.
-    - repeat simpl_result_all.
-      repeat simpl_result_all.
-      inversion H; subst.
-      constructor; eauto using interp_expr_det_safe.
-    - repeat simpl_result_all.
-      repeat simpl_result_all.
-      econstructor; eauto using interp_expr_det_safe.
-  Qed.
-
-  Lemma interp_matches_safe:
-    forall this matches vsets,
-      Interpreter.interp_matches ge this matches = Ok vsets ->
-      Semantics.exec_matches ge read_ndetbit this matches vsets.
-  Proof.
-    unfold Semantics.exec_matches.
-    induction matches; simpl.
-    intros.
-    - inversion H.
-      constructor.
-    - intros.
-      repeat simpl_result_all.
-      repeat simpl_result_all.
-      inversion H.
-      subst.
-      constructor; eauto.
-      eapply interp_match_safe; auto.
-  Qed.
-
   Lemma interp_table_entry_safe:
     forall this entries vset,
       Interpreter.interp_table_entry this entries = vset ->
@@ -830,7 +787,7 @@ Section InterpreterSafe.
     destruct entries.
     simpl in *.
     repeat simpl_result_all.
-    econstructor; eauto using interp_matches_safe.
+    econstructor; eauto.
     destruct (PeanoNat.Nat.eqb _ _); congruence.
   Qed.
 

--- a/coq/lib/P4light/Semantics/InterpreterSafe.v
+++ b/coq/lib/P4light/Semantics/InterpreterSafe.v
@@ -822,8 +822,8 @@ Section InterpreterSafe.
 
   Lemma interp_table_entry_safe:
     forall this entries vset,
-      Interpreter.interp_table_entry ge this entries = Ok vset ->
-      Semantics.exec_table_entry ge read_ndetbit this entries vset.
+      Interpreter.interp_table_entry this entries = vset ->
+      Semantics.exec_table_entry (tags_t:=tags_t) read_ndetbit this entries vset.
   Proof.
     unfold Interpreter.interp_table_entry.
     intros.
@@ -831,13 +831,13 @@ Section InterpreterSafe.
     simpl in *.
     repeat simpl_result_all.
     econstructor; eauto using interp_matches_safe.
-    destruct (PeanoNat.Nat.eqb _ _); simpl_result_all; congruence.
+    destruct (PeanoNat.Nat.eqb _ _); congruence.
   Qed.
 
   Lemma interp_table_entries_safe:
     forall entries this vsets,
-      Interpreter.interp_table_entries ge this entries = Ok vsets ->
-      Semantics.exec_table_entries ge read_ndetbit this entries vsets.
+      Interpreter.interp_table_entries this entries = vsets ->
+      Semantics.exec_table_entries (tags_t:=tags_t) read_ndetbit this entries vsets.
   Proof.
     unfold Semantics.exec_table_entries.
     induction entries; intros.

--- a/coq/lib/P4light/Semantics/Ops.v
+++ b/coq/lib/P4light/Semantics/Ops.v
@@ -78,7 +78,7 @@ Section Ops.
   Definition dummy_tags := @default tags_t _.
 
   Notation Val := (@ValueBase bool).
-  Notation ValSet := (@ValueSet tags_t).
+  Notation ValSet := ValueSet.
   Definition Fields (A : Type):= AList.StringAList A.
 
   Definition eval_unary_op (op : OpUni) (v : Val) : option Val :=

--- a/coq/lib/P4light/Syntax/Value.v
+++ b/coq/lib/P4light/Syntax/Value.v
@@ -30,8 +30,6 @@ Section Value.
   | ValLeftBitAccess (expr: ValueLvalue) (msb: N) (lsb: N)
   | ValLeftArrayAccess (expr: ValueLvalue) (idx: Z).
 
-  Context {tags_t : Type}.
-
   Inductive ValueSet:=
   | ValSetSingleton (value: (@ValueBase bool))
   | ValSetUniversal
@@ -39,10 +37,12 @@ Section Value.
   | ValSetRange (lo: (@ValueBase bool)) (hi: (@ValueBase bool))
   | ValSetProd (_: list ValueSet)
   | ValSetLpm (nbits: N) (value: (@ValueBase bool))
-  | ValSetValueSet (size: N) (members: list (list (@Syntax.Match tags_t))) (sets: list ValueSet).
+  | ValSetValueSet (size: N) (members: list (list ValueSet)) (sets: list ValueSet).
 
   Definition ValueLoc := string.
 
+  Context {tags_t : Type}.
+  
   Inductive ValueTable :=
   | MkValTable (name: string) (keys: list (@Syntax.TableKey tags_t))
                (actions: list (@Syntax.TableActionRef tags_t))


### PR DESCRIPTION
Proposed changes
- Remove P4light's `Match` from `ValueSet`.
- Replace `Match` with `ValueSet` in `Target.v`

Questions:
1. In `ValSetValueSet` what is is the purpose of the members list? It was a list of list of `Match` but this has been replaced with `ValueSet`.
2. In `Semantics.v` `unwrap_table_entry` was used in `load_decl` to map a `TableEntry` to a `table_entry` and put it in a `genv`. Now the `Match`s in a `TableEntry` need to be converted to `ValueSet` which requires a relation. Perhaps should `TableEntry` be used in place of `table_entry` in `FTable`, so matches in tables are evaluated upon table invocation? Or maybe `load_decl` needs to be a relation too...