### PR TITLE
Fix the coq installation problem.

### DIFF
--- a/coq/lib/dune
+++ b/coq/lib/dune
@@ -1,5 +1,6 @@
 (coq.theory
  (name Poulet4)
+ (package poulet4)
  (synopsis "Coq definitions for Petr4")
  (modules (:standard)))
 


### PR DESCRIPTION
Fix the coq file installation problem by adding back `(package poulet4)` to the file `coq/lib/dune` , below `(name Poulet4)`.

Ref: https://dune.readthedocs.io/en/latest/coq.html#coq-theory
If the `package` field is present, Dune generates install rules for the `.vo` files of the theory. `pkg_name` must be a valid package name.

Since last time, this line is moved by comment message "fix build". I'm not sure it will break ci. It builds and installs without problem in my machine.