### PR TITLE
Unembed ValueSet

### DIFF
--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Interpreter.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Interpreter.v
@@ -284,4 +284,20 @@ Section Parser.
         mret $ Parser.Range (w1 PW n1) (w2 PW n2)
     | _ => None
     end.
+
+  Definition interpret_table_entry (entry : table_entry (Expression := Expr.e)) : option (Parser.pat * action_ref) :=
+    let 'mk_table_entry matches action_ref := entry in
+    let^ pats := unembed_valsets matches in
+    (Parser.Lists pats, action_ref).
+
+  Lemma interpret_table_entry_sound :
+    forall entry pat action_ref,
+      interpret_table_entry entry = Some (pat, action_ref) -> table_entry_big_step entry pat action_ref.
+  Proof.
+    unfold interpret_table_entry. intros. destruct entry.
+    cbn in *. unfold option_bind in *.
+    destruct (unembed_valsets matches) eqn:HSome; try discriminate. inv H.
+    constructor. apply unembed_valsets_sound. assumption.
+  Qed.
+
 End Parser.

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Value/Embed.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Value/Embed.v
@@ -306,6 +306,22 @@ Section Embed.
   | embed_pat_lists ps vss :
     Forall2 embed_pat_valset ps vss ->
     embed_pat_valset (Parser.Lists ps) (ValSetProd vss).
+
+  Fixpoint unembed_valset (val : ValueSet) : option Parser.pat :=
+    match val with
+    | ValSetSingleton (ValBaseBit bits) => mret $ uncurry Parser.Bit $ BitArith.from_lbool bits
+    | _ => None
+    end.
+
+  Lemma unembed_valset_sound :
+    forall val pat, unembed_valset val = Some pat -> embed_pat_valset pat val.
+  Proof.
+    intros. destruct val; try discriminate.
+    - destruct value; try discriminate. inv H. cbn.
+      replace (ValBaseBit value) with (ValBaseBit (to_lbool (Z.to_N (Zcomplements.Zlength value)) (BitArith.lbool_to_val value 1 0))).
+      + constructor.
+      + f_equal. apply to_lbool_lbool_to_val.
+  Qed.
   
   Fixpoint snd_map {A : Type} {B : Type} (func : A -> B) (l : list (string * A)) :=
     match l with 


### PR DESCRIPTION
Writes a function for "un-embedding" a `ValueSet` into a parser pattern and uses this to develop and verify the soundness of an interpreter for table entries.