### PR TITLE
Option Tactic Notations

### DIFF
--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Interpreter.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Interpreter.v
@@ -62,43 +62,31 @@ Section Exp.
   Theorem interpret_exp_sound : 
     forall e v, interpret_exp e = Some v -> ⟨ ϵ, e ⟩ ⇓ v.
   Proof.
-    induction e using custom_exp_ind.
+    induction e using custom_exp_ind; unravel in *.
     - intros. inv H. constructor.
     - intros. inv H. constructor.
     - intros. inv H. constructor.
     - intros. inv H. constructor.
     - intros. inv H. constructor. assumption.
+    - intros. match_some_inv. econstructor; eauto.
+    - intros. match_some_inv. econstructor; eauto.
+    - intros. match_some_inv. econstructor; eauto.
     - simpl. unfold option_bind. intros.
-      destruct (interpret_exp e); try discriminate.
-      econstructor; eauto.
-    - simpl. unfold option_bind. intros.
-      destruct (interpret_exp e); try discriminate.
-      econstructor; eauto.
-    - simpl. unfold option_bind. intros.
-      destruct (interpret_exp e); try discriminate.
-      econstructor; eauto.
-    - simpl. unfold option_bind. intros.
-      destruct (interpret_exp e1); try discriminate.
-      destruct (interpret_exp e2); try discriminate.
-      econstructor; eauto.
-    - simpl. unfold option_bind, map_monad, "∘". intros.
-      destruct (sequence (map interpret_exp es)) eqn:E; try discriminate.
-      inv H0.
-      apply sequence_Forall2 in E.
-      apply Forall2_map_comm_fwd in E.
+      repeat match_some_inv. econstructor; eauto.
+    - intros. match_some_inv as Hsome. some_inv.
+      rewrite map_monad_some in Hsome.
       constructor. generalize dependent l0.
-      induction es; intros; inv H; inv E; constructor; auto.
-    - simpl. unfold option_bind, interpret_index, index, to_bit. intros.
+      induction es; intros; inv H; inv Hsome; constructor; auto.
+    - unfold interpret_index, index, to_bit. intros.
       destruct (interpret_exp e1);
       destruct (interpret_exp e2);
       try discriminate.
       destruct t; destruct t0; try discriminate.
       econstructor; eauto.
-    - simpl. unfold option_bind, index. intros.
-      destruct (interpret_exp e); try discriminate.
+    - unfold index. intros. match_some_inv.
       destruct t; try discriminate.
       econstructor; eauto.
-    - intros. unravel in *. inv H. constructor.
+    - intros. inv H. constructor.
     Qed.
 
     Theorem interpret_exp_complete :
@@ -178,16 +166,13 @@ Section Exp.
     Proof.
       induction e; try discriminate; intros; inv H; unfold option_bind in *.
       - constructor.
-      - destruct (interpret_lexp e) eqn:?; try discriminate. inv H1.
-        constructor. auto.
-      - unfold to_bit in *.
-        destruct (interpret_lexp e1); try discriminate.
+      - match_some_inv. some_inv. constructor. auto.
+      - unfold to_bit in *. match_some_inv.
         destruct (interpret_exp e2) eqn:?; try discriminate.
         destruct t0; try discriminate.
         inv H1. econstructor; eauto. 
         apply interpret_exp_sound. eauto.
-      - destruct (interpret_lexp e); try discriminate.
-        inv H1. constructor. auto.
+      - match_some_inv. some_inv. econstructor. auto.
     Qed.
 
     Lemma interpret_lexp_complete :
@@ -230,9 +215,8 @@ Section Exp.
     Proof.
       intros. destruct pat; inv H.
       - constructor.
-      - unfold option_bind in *.
-        destruct (interpret_exp discriminee) eqn:?; try discriminate.
-        inv H1. constructor. apply interpret_exp_sound. assumption.
+      - unravel in *. match_some_inv. some_inv.
+        constructor. apply interpret_exp_sound. assumption.
     Qed.
 
     Lemma interpret_parser_exp_complete :

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Value/Auxiliary.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Value/Auxiliary.v
@@ -8,20 +8,6 @@ From Poulet4 Require Import P4cub.Syntax.AST
   P4cub.Syntax.CubNotations Utils.ForallMap.
 Import String.
 
-(* TODO: Also in [P4light/Semantics/Typing/Utility.v]
-   Should be moved to somewhere in [Utils]. *)
-Ltac some_inv :=
-  match goal with
-  | H: Some _ = Some _ |- _ => inv H
-  end.
-
-Ltac match_some_inv :=
-  match goal with
-  | H: match ?trm with Some _ => _ | None => _ end = Some _
-    |- _ => destruct trm as [? |] eqn:? ; cbn in *;
-          try discriminate
-  end.
-
 Local Open Scope val_scope.
 Local Open Scope type_scope.
 

--- a/coq/lib/P4light/Semantics/Typing/Lemmas.v
+++ b/coq/lib/P4light/Semantics/Typing/Lemmas.v
@@ -190,11 +190,11 @@ Section Lemmas.
       inversion Hut; subst;
         inversion Hvt; subst;
           unfold Ops.eval_unary_op in Heval;
-          try discriminate; try some_inv; auto;
+          try discriminate; try some_ok_inv; auto;
             try match goal with
                 | H: context [let (_,_) := P4Arith.BitArith.from_lbool ?bs in _]
                   |- _ => destruct (P4Arith.BitArith.from_lbool bs)
-                    as [w' n] eqn:Hbs; some_inv;
+                    as [w' n] eqn:Hbs; some_ok_inv;
                           try inv_numeric; try inv_numeric_width
                 end;
             try bitint_length_rewrite; unfold P4Arith.to_lbool;
@@ -215,7 +215,7 @@ Section Lemmas.
         inversion Hvt1; subst; inversion Hvt2; subst;
           cbn in *; try discriminate;
             try inv_numeric; try inv_numeric_width;
-              try some_inv;
+              try some_ok_inv;
               try rewrite <- Nnat.Nat2N.inj_add;
               try match goal with
                   | |- ⊢ᵥ ValBaseBit (?l ++ ?r) \: TypBit (N.of_nat (length ?l + length ?r))
@@ -224,7 +224,7 @@ Section Lemmas.
                     => rewrite <- app_length
                   end;
               repeat if_destruct;
-              try match_some_inv; try some_inv; auto;
+              try match_some_ok_inv; try some_ok_inv; auto;
                 try bitint_length_rewrite;
                 unfold P4Arith.to_lbool;
                 try rewrite length_to_lbool'; cbn;
@@ -251,7 +251,7 @@ Section Lemmas.
     induction Ht using my_Eq_type_ind;
       intros ge r Hget; cbn in *;
       autounfold with option_monad in *; cbn in *;
-      repeat match_some_inv; some_inv; eauto;
+      repeat match_some_ok_inv; some_ok_inv; eauto;
       try match goal with
           | IH: Forall
                   ((fun t => forall ge r,
@@ -295,8 +295,8 @@ Section Lemmas.
     intros ge o t t1 t2 r1 r2 Hbt Hr1 Hr2.
     inversion Hbt; subst;
       try inv_numeric; try inv_numeric_width;
-        cbn in *; repeat some_inv; eauto;
-          try (rewrite Hr1 in Hr2; some_inv; eauto).
+        cbn in *; repeat some_ok_inv; eauto;
+          try (rewrite Hr1 in Hr2; some_ok_inv; eauto).
   Qed.
 
   Lemma eval_binary_op_eq_ex : forall (t : typ) v1 v2,
@@ -484,7 +484,7 @@ Section Lemmas.
     intros t r ts ge Hge Hmem.
     inversion Hmem; subst; cbn in *;
       autounfold with option_monad in *;
-      try match_some_inv; try some_inv;
+      try match_some_ok_inv; try some_ok_inv;
         try match goal with
             | H: sequence _ = Some ?rs
               |- exists _, _ => exists rs; auto
@@ -666,7 +666,7 @@ Section Lemmas.
     induction hc using my_cast_type_ind;
       intros r1 r2 ge1 hr1 ge2 hr2; cbn in *;
       autounfold with option_monad in *;
-      repeat match_some_inv; repeat some_inv; eauto;
+      repeat match_some_ok_inv; repeat some_ok_inv; eauto;
       normalize_cast_seq; constructor; eauto;
       lazymatch goal with
       | |- Forall2 (fun _ => _) _ _ => eapply get_real_cast_type_case1; eauto
@@ -707,8 +707,8 @@ Section Lemmas.
           assert (Datatypes.length x = Datatypes.length y) as hlen by
               (eapply length_eq_eval_cast_type; eauto);
           rewrite hlen in H; autorewrite with core in H; cbn in H
-      | _: match _ with | Some _ | _ => _ end = Some _ |- _ => match_some_inv
-      | _: Some _ = Some _ |- _ => some_inv
+      | _: match _ with | Some _ | _ => _ end = Some _ |- _ => match_some_ok_inv
+      | _: Some _ = Some _ |- _ => some_ok_inv
       | |- ⊢ᵥ ValBaseStruct _ \: TypStruct _ => constructor; auto
       | |- ⊢ᵥ ValBaseHeader _ _ \: TypHeader _ => constructor; auto
       end.
@@ -762,7 +762,7 @@ Section Lemmas.
     induction xts as [| [x t] xts ih];
       intros [| v vs] [| T TS] hc ihc hvt [| [y V] VS] H;
       inv hc; inv ihc; inv hvt; cbn in *;
-      repeat match_some_inv; some_inv;
+      repeat match_some_ok_inv; some_ok_inv;
       try discriminate; eauto.
     pose proof ih _ _ H5 H7 H9 _ Heqo0 as [hfst hsnd]; clear ih.
     rewrite hfst; split; eauto.
@@ -819,13 +819,13 @@ Section Lemmas.
         h_fst_xts_yts h_snd_xts_yts ih_xts_yts
         h_fst_vs_xts h_snd_vs_xts;
       inv h_snd_xts_yts; inv ih_xts_yts; inv h_snd_vs_xts;
-      cbn in *; repeat match_some_inv; some_inv; auto.
+      cbn in *; repeat match_some_ok_inv; some_ok_inv; auto.
     injection h_fst_xts_yts as hxy h_fst_xts_yts.
     injection h_fst_vs_xts as hzx h_fst_vs_xts; subst.
     unfold StringEqDec in *.
     rewrite AList.get_eq_cons in Heqo by
         auto using Equivalence.equiv_reflexive_obligation_1.
-    some_inv.
+    some_ok_inv.
     destruct (string_dec (P4String.str y) (P4String.str y))
       as [bruh | bruh]; try contradiction; clear bruh.
     pose proof ih _ _ Heqo1 _ h_fst_xts_yts
@@ -843,7 +843,7 @@ Section Lemmas.
       generalize dependent v1.
     induction hcast using my_cast_type_ind;
       intros v1 v2 heval hv1; inv hv1; cbn in *;
-      autorewrite with core in *; try some_inv; auto 2.
+      autorewrite with core in *; try some_ok_inv; auto 2.
     - destruct v as [| [] []];
         cbn in *; try discriminate; inv heval; auto.
     - constructor.
@@ -857,7 +857,7 @@ Section Lemmas.
     - pose proof length_to_lbool w v as h.
       apply f_equal with (f:=N.of_nat) in h.
       autorewrite with core in h; rewrite <- h at 2; auto.
-    - inv H1; autorewrite with core in *; some_inv; auto.
+    - inv H1; autorewrite with core in *; some_ok_inv; auto.
     - pose proof length_to_lbool
         (N.of_nat (List.length v))
         (IntArith.mod_bound
@@ -869,16 +869,16 @@ Section Lemmas.
         w (IntArith.mod_bound (pos_of_N w) v) as h.
       apply f_equal with (f:=N.of_nat) in h.
       autorewrite with core in h; rewrite <- h at 3; auto.
-    - inv H1; autorewrite with core in *; some_inv; auto.
-    - inv H1; autorewrite with core in *; some_inv; auto.
-    - inv H1; autorewrite with core in *; some_inv; auto.
+    - inv H1; autorewrite with core in *; some_ok_inv; auto.
+    - inv H1; autorewrite with core in *; some_ok_inv; auto.
+    - inv H1; autorewrite with core in *; some_ok_inv; auto.
     - normalize_cast_match. eapply eval_cast_types_case1; eauto.
     - normalize_cast_match. eapply eval_cast_types_case2; eauto.
     - normalize_cast_match. eapply eval_cast_types_case2; eauto.
     - normalize_cast_match. eapply eval_cast_types_case1; eauto.
     - normalize_cast_match. eapply eval_cast_types_case2; eauto.
     - normalize_cast_match. eapply eval_cast_types_case2; eauto.
-    - match_some_inv; some_inv.
+    - match_some_ok_inv; some_ok_inv.
       constructor.
       generalize dependent ts1;
         generalize dependent l;
@@ -886,7 +886,7 @@ Section Lemmas.
       induction ts2 as [| T TS ih];
         intros [| v vs] [| V VS] h [| t ts] hc ihc hvt;
         inv hc; inv ihc; inv hvt;
-        repeat match_some_inv; some_inv; eauto.
+        repeat match_some_ok_inv; some_ok_inv; eauto.
   Qed.
 
   Lemma eval_cast_ex_case:
@@ -1464,7 +1464,7 @@ Section Lemmas.
     destruct Htst as [[y t] Hyt].
     specialize Htsl with (u := (y,t)) (v := (x,r)); cbn in *.
     assert (HIn : List.In ((y,t),(x,r)) (combine xts xrs)) by eauto.
-    apply Htsl in HIn. match_some_inv; some_inv; eauto.
+    apply Htsl in HIn. match_some_ok_inv; some_ok_inv; eauto.
   Qed.
 
   Local Hint Resolve delta_genv_prop_ok_typ_nil_alist : core.
@@ -1507,11 +1507,11 @@ Section Lemmas.
     apply delta_genv_prop_ok_typ_nil_ind;
       autounfold with ind_def; cbn;
         autounfold with option_monad;
-        try (intros; repeat match_some_inv;
-             some_inv; eauto; assumption).
+        try (intros; repeat match_some_ok_inv;
+             some_ok_inv; eauto; assumption).
     - intros d X t mems Ht IHt ge r Hge Hr.
       destruct t as [t |]; inversion IHt; subst;
-        try match_some_inv; some_inv; eauto.
+        try match_some_ok_inv; some_ok_inv; eauto.
       constructor; constructor; cbn.
       apply H0 in Heqo; eauto.
     - intros d X HXd ge r Hge Hr.
@@ -1523,23 +1523,23 @@ Section Lemmas.
     - intros d X t Ht IHt ge r Hge Hr.
       apply IHt in Hr; auto.
     - intros d Xs Ts ps Hps IHps ge r Hge Hr.
-      match_some_inv; some_inv.
+      match_some_ok_inv; some_ok_inv.
       constructor; autorewrite with core.
       eapply delta_genv_prop_ok_param_nil_list in Hps;
         eauto using delta_genv_prop_removes.
     - intros d Xs Ys ps t Hps IHps Ht IHts ge r Hge Hr.
-      repeat match_some_inv; some_inv.
+      repeat match_some_ok_inv; some_ok_inv.
       constructor; autorewrite with core.
       eapply delta_genv_prop_ok_param_nil_list in Heqo0;
         eauto using delta_genv_prop_removes.
       eapply IHts; eauto using delta_genv_prop_removes.
     - intros d Xs ps Hps IHps ge r Hge Hr.
-      match_some_inv; some_inv.
+      match_some_ok_inv; some_ok_inv.
       constructor; autorewrite with core.
       eapply delta_genv_prop_ok_param_nil_list in Hps;
         eauto using delta_genv_prop_removes.
     - intros d Xs ps k t Hps IHps Ht IHt ge r Hge Hr.
-      repeat match_some_inv; some_inv.
+      repeat match_some_ok_inv; some_ok_inv.
       constructor; autorewrite with core.
       eapply delta_genv_prop_ok_param_nil_list in Hps;
         eauto using delta_genv_prop_removes.
@@ -1554,7 +1554,7 @@ Section Lemmas.
     intros ts rs t r ge Hts Hrs Htr;
       inversion Hts; subst; inversion Hrs; subst;
         cbn in *; autounfold with option_monad in *;
-          match_some_inv; some_inv; reflexivity.
+          match_some_ok_inv; some_ok_inv; reflexivity.
   Qed.
 
   Lemma exec_expr_call_False :
@@ -1583,7 +1583,7 @@ Section Lemmas.
     destruct l as [l | l]; cbn in *; try discriminate.
     unfold PathMap.get in *.
     rewrite FuncAsMap.get_map_map in hltv.
-    unfold option_map in hltv. match_some_inv; some_inv.
+    unfold option_map in hltv. match_some_ok_inv; some_ok_inv.
     eauto.
   Qed.
 
@@ -1617,7 +1617,7 @@ Section Lemmas.
     unfold PathMap.get in *.
     rewrite FuncAsMap.get_map_map in ht.
     unfold option_map in ht.
-    match_some_inv; some_inv.
+    match_some_ok_inv; some_ok_inv.
     rename p into t.
     pose proof h _ _ eq_refl hv as (r & hr & hvr); clear h.
     unfold try_get_real_type, "∘". rewrite hr. assumption.
@@ -1665,7 +1665,7 @@ Section Lemmas.
     induction hread; intros t hlv; inv hlv;
       eauto using get_member_types.
     - pose proof IHhread hG _ H8 as hsv. inv hsv.
-      cbn in H. some_inv.
+      cbn in H. some_ok_inv.
       assert (hlen: (N.to_nat lo <= N.to_nat hi < List.length bitsbl)%nat) by lia.
       pose proof Ops.bitstring_slice_length _ _ _ hlen as h.
       assert (heq: (N.to_nat hi - N.to_nat lo + 1)%nat = N.to_nat (hi - lo + 1)%N) by lia.
@@ -1682,7 +1682,7 @@ Section Lemmas.
         eapply Forall_nth_error in H7; eauto.
       + rewrite nth_overflow by lia.
         destruct headers; cbn in *; try discriminate.
-        some_inv. inv H7; auto.
+        some_ok_inv. inv H7; auto.
   Qed.
   
   Lemma exec_read_ex :
@@ -1749,9 +1749,9 @@ Section Lemmas.
     intros f vs; induction vs as [| [x v] vs ih];
       intros [| [y v'] vs'] h H; cbn in *;
       unfold option_bind in h; inv H;
-      repeat match_some_inv; discriminate || some_inv; auto.
+      repeat match_some_ok_inv; discriminate || some_ok_inv; auto.
     destruct H2 as (hdr & bits & hhdr); subst. cbn in *.
-    some_inv. constructor; eauto.
+    some_ok_inv. constructor; eauto.
   Qed.
   
   Lemma havoc_headers_all_values_val_typ : forall f (ts : list (string * typ)) vs vs',
@@ -1762,7 +1762,7 @@ Section Lemmas.
     unfold AList.all_values, lift_option_kv.
     intros f ts; induction ts as [| [x t] ts ih];
       intros [| [y v] vs] [| [z v'] vs'] hvs' hvts; cbn in *;
-      try discriminate; inv hvts; repeat match_some_inv; some_inv; auto.
+      try discriminate; inv hvts; repeat match_some_ok_inv; some_ok_inv; auto.
     destruct H2 as [? hvt]; subst.
     eauto using havoc_header_val_typ.
   Qed.
@@ -1815,7 +1815,7 @@ Section Lemmas.
         unfold "===" in *; split; auto using uninit_sval_of_sval_preserves_typ.
     - constructor; auto.
       + unfold update_union_member in H.
-        match_some_inv.
+        match_some_ok_inv.
         pose proof havoc_headers_is_header _ _ _ Heqo H2 as h.
         clear dependent ts0.
         pose proof AListUtil.AList_set_some_split
@@ -1826,7 +1826,7 @@ Section Lemmas.
         rewrite Forall_app in *.
         destruct h as [h1 h2]; inv h2. split; eauto.
       + unfold update_union_member in H.
-        match_some_inv.
+        match_some_ok_inv.
         pose proof havoc_headers_all_values_val_typ _ _ _ _ Heqo H3 as h.
         solve_update_member_preserves_typ.
   Qed.
@@ -2036,11 +2036,11 @@ Section Lemmas.
         destruct loc as [loc | loc]; cbn in *; try discriminate.
         destruct l as [l | l]; cbn in *; try discriminate.
         destruct (list_eq_dec string_dec l loc) as [hlloc | hlloc]; subst.
-        * rewrite H1 in htyp_of. some_inv.
+        * rewrite H1 in htyp_of. some_ok_inv.
           pose proof PathMap.get_set_same loc rhs st as h.
           unfold PathMap.get,FuncAsMap.get in *. rewrite h in hloc_to_sval.
           cbn in *. unfold ok in *.
-          some_inv. assumption.
+          some_ok_inv. assumption.
         * pose proof PathMap.get_set_diff l loc rhs st hlloc as h.
           specialize hG with (LInstance l) t' v as H. cbn in H.
           unfold PathMap.get,FuncAsMap.get in *.

--- a/coq/lib/P4light/Semantics/Typing/Rules.v
+++ b/coq/lib/P4light/Semantics/Typing/Rules.v
@@ -255,7 +255,7 @@ Section Soundness.
         + apply He1' in Hev1 as Hev1'; clear He1'.
           destruct Hev1' as (r1 & Hr1 & Hvr1).
           cbn in Hr1. autounfold with option_monad in *.
-          repeat match_some_inv; repeat some_inv.
+          repeat match_some_ok_inv; repeat some_ok_inv.
           cbn in Hvr1; inversion Hvr1; subst.
           assert (Hsv1: exists v1, sval_to_val rob (ValBaseStack vs n0) v1)
             by eauto using exec_val_exists.
@@ -270,7 +270,7 @@ Section Soundness.
           destruct Hsv2 as [v2 Hsv2].
           assert (Hxed2: exec_expr_det ge rob this st e2 v2) by eauto.
           apply He2' in Hev2 as (r2 & Hr2 & Hvr2);
-            clear He2'; cbn in *; some_inv; cbn in *; inv Hvr2.
+            clear He2'; cbn in *; some_ok_inv; cbn in *; inv Hvr2.
           inversion Hsv2; subst.
           assert (Hz: exists z, array_access_idx_to_z (ValBaseBit lb') = Some z)
             by (cbn; eauto).
@@ -280,13 +280,13 @@ Section Soundness.
           destruct Γ as [Γv Γc] eqn:HeqΓ; cbn in *.
           destruct Hlvt as (r & hr & hlvr).
           unfold option_bind at 1 in hr.
-          match_some_inv; some_inv.
+          match_some_ok_inv; some_ok_inv.
           eexists; split; eauto.
           cbn in hlvr.
           econstructor; eauto.
           inv H10.
-          apply He2' in H as (r2 & Hr2 & Hvr2); some_inv; cbn in *.
-          inv Hvr2; inv H0; cbn in *; some_inv.
+          apply He2' in H as (r2 & Hr2 & Hvr2); some_ok_inv; cbn in *.
+          inv Hvr2; inv H0; cbn in *; some_ok_inv.
           apply BitArith.lbool_to_val_lower; lia.
     Qed.
 
@@ -347,11 +347,11 @@ Section Soundness.
           destruct Hbits as (bits & ws & Hbit).
           econstructor; eauto.
           inv Hr; cbn in *; inv Hvr.
-          inv Hsv; cbn in *; some_inv.
+          inv Hsv; cbn in *; some_ok_inv.
           apply Forall2_length in H0; lia.
         + clear v Hev lv s Hlvs; intros lv s Hlvs; inv Hlvs; inv H10.
-          apply He' in H as (r & Hr & Hsvr); clear He'; cbn in *; some_inv.
-          cbn in *; inv Hsvr; inv H0; cbn in *; some_inv.
+          apply He' in H as (r & Hr & Hsvr); clear He'; cbn in *; some_ok_inv.
+          cbn in *; inv Hsvr; inv H0; cbn in *; some_ok_inv.
           apply Helv' in H9 as Hlvt.
           apply Forall2_length in H1.
           rewrite H1 in Hlvt.
@@ -507,8 +507,8 @@ Section Soundness.
           induction es as [| [x e] es IHes];
             intros [| r rs] Hrs; cbn in *; try discriminate;
               try specialize IHes with rs;
-              repeat match_some_inv; some_inv; try reflexivity.
-          intuition; match_some_inv; some_inv; reflexivity.
+              repeat match_some_ok_inv; some_ok_inv; try reflexivity.
+          intuition; match_some_ok_inv; some_ok_inv; reflexivity.
         + constructor.
           * rewrite <- Forall2_sequence_iff in Hesrs.
             repeat rewrite <- ForallMap.Forall2_map_l in Hesrs.
@@ -565,7 +565,7 @@ Section Soundness.
             try inv_numeric; try inv_numeric_width;
               try match goal with
                   | H: _ = typ_of_expr _ |- _ => rewrite <- H in *
-                  end; cbn in *; try some_inv; auto. }
+                  end; cbn in *; try some_ok_inv; auto. }
         assert (Hutr_normᵗ: unary_type o (normᵗ r) (normᵗ r)).
         { inversion Hutr; subst;
             try inv_numeric;
@@ -591,7 +591,7 @@ Section Soundness.
         { inversion Hut; subst; try inv_numeric; try inv_numeric_width;
             try match goal with
                 | H: _ = typ_of_expr _ |- _ => rewrite <- H in *
-                end; cbn in *; try some_inv; auto. }
+                end; cbn in *; try some_ok_inv; auto. }
         destruct Hr_eq as [Het Hrr]; subst r.
         rewrite Hrr in Hut; eauto.
       - intro H; inv H.
@@ -779,8 +779,8 @@ Section Soundness.
     Proof using.
       intros tag X M E mems dir Hget Hmem.
       soundtac; split; auto; inv Hrn.
-      - rewrite Hget in H7; some_inv; auto.
-      - rewrite Hget in H11; some_inv.
+      - rewrite Hget in H7; some_ok_inv; auto.
+      - rewrite Hget in H11; some_ok_inv.
     Qed.
 
     (*Theorem senum_member_sound :
@@ -861,7 +861,7 @@ Section Soundness.
             induction ts as [| [y t] ts IHts];
               intros [| [z r] rs] Hrs t' Hxt';
               cbn in *; try discriminate;
-                repeat match_some_inv; repeat some_inv.
+                repeat match_some_ok_inv; repeat some_ok_inv.
             inversion H0; subst.
             pose proof P4String.equiv_reflect x z as Hxz.
             inversion Hxz; subst.
@@ -903,13 +903,13 @@ Section Soundness.
           induction ts as [| [y t] ts IHts];
             intros [| [z r] rs] Hrs t' Hxt' r' Ht'r';
             cbn in *; try discriminate;
-              repeat match_some_inv; repeat some_inv.
+              repeat match_some_ok_inv; repeat some_ok_inv.
           inversion H0; subst.
           pose proof P4String.equiv_reflect x z as Hxz.
           inversion Hxz; subst.
-          + rewrite AList.get_eq_cons in Hxt' by assumption; some_inv.
+          + rewrite AList.get_eq_cons in Hxt' by assumption; some_ok_inv.
             rewrite AList.get_eq_cons by assumption.
-            rewrite Heqo2 in Ht'r'; some_inv; reflexivity.
+            rewrite Heqo2 in Ht'r'; some_ok_inv; reflexivity.
           + rewrite AList.get_neq_cons in Hxt' by assumption.
             rewrite AList.get_neq_cons by assumption; eauto. }
         rewrite P4String.get_clear_AList_tags in Hlem3'; eauto.
@@ -936,15 +936,15 @@ Section Soundness.
           induction ts as [| [[iy y] t] ts ih]; intros [| [[iz z] r] rs] hrs ty hty;
             cbn in *; try discriminate.
           - unfold option_bind at 1 2 in hrs.
-            repeat match_some_inv; some_inv.
+            repeat match_some_ok_inv; some_ok_inv.
             unfold option_bind at 1 in hrs.
-            match_some_inv.
+            match_some_ok_inv.
           - unfold option_bind at 1 2 in hrs.
-            repeat match_some_inv; some_inv.
+            repeat match_some_ok_inv; some_ok_inv.
             unfold option_bind at 1 in hrs.
-            match_some_inv; some_inv.
+            match_some_ok_inv; some_ok_inv.
             destruct (string_dec z x) as [hzx | hzx]; subst.
-            + rewrite AList.get_eq_cons in hty by intuition; some_inv.
+            + rewrite AList.get_eq_cons in hty by intuition; some_ok_inv.
               rewrite AList.get_eq_cons by intuition.
               eauto.
             + rewrite AList.get_neq_cons in hty by firstorder.
@@ -1038,7 +1038,7 @@ Section Soundness.
       split; [| split].
       - apply Hxe1 in Hesv1 as Hxe1'; clear Hxe1.
         destruct Hxe1' as (r1 & Hr1 & Hvr1).
-        rewrite <- Ht1 in Hr1; cbn in *; some_inv.
+        rewrite <- Ht1 in Hr1; cbn in *; some_ok_inv.
         cbn in *; inv Hvr1.
         rename b into ob.
         assert (Hv1: exists v1, sval_to_val rob (ValBaseBool ob) v1)
@@ -1051,7 +1051,7 @@ Section Soundness.
         clear dependent sv3.
         intros v Hev; inv Hev; inv H14.
         apply Hxe1 in H13 as (r1 & Hr1 & Hsvr1).
-        rewrite <- Ht1 in Hr1; cbn in *; some_inv; cbn in *.
+        rewrite <- Ht1 in Hr1; cbn in *; some_ok_inv; cbn in *.
         destruct b.
         + firstorder.
         + rewrite Ht3; firstorder.
@@ -1112,7 +1112,7 @@ Section Soundness.
             pose proof exec_val_preserves_typ
               _ _ _ Hsv2 _ hsvr2 as hvrt2.
             pose proof Helv1 _ _ Helvs1 as (r & hr & hlvr).
-            rewrite Hte1e2, hr2 in hr; some_inv.
+            rewrite Hte1e2, hr2 in hr; some_ok_inv.
             replace (fun x : typ => normᵗ (try_get_real_type ge x)) with
               (normᵗ ∘ try_get_real_type ge) in hlvr by reflexivity.
             unfold gamma_expr_ok, gamma_expr_prop,gamma_var_prop in *.
@@ -1141,7 +1141,7 @@ Section Soundness.
           destruct (is_continue sig) eqn:?H; [| subst; assumption].
           pose proof He2 _ H as (r2 & hr2 & hsvr2).
           pose proof Helv1 _ _  H8 as (r1 & hr1 & hlvr1).
-          rewrite Hte1e2,hr2 in hr1. some_inv.
+          rewrite Hte1e2,hr2 in hr1. some_ok_inv.
           assert (⊢ᵥ v \: normᵗ r1) by eauto.
           assert (hsvr1: ⊢ᵥ sv \: normᵗ r1) by eauto.
           replace (fun x : typ => normᵗ (try_get_real_type ge x)) with
@@ -1221,7 +1221,7 @@ Section Soundness.
       assert (Hxed: exec_expr_det ge rob this st e v) by eauto.
       rewrite <- Het in He'; cbn in He'.
       apply He' in Hesv as (r & Hr & Hsvr).
-      some_inv; cbn in Hsvr; inv Hsvr; inv Hv.
+      some_ok_inv; cbn in Hsvr; inv Hsvr; inv Hv.
       destruct s2 as [s2 |]; inv Hs2; inv H6; inv H8.
       - destruct H1 as [Γ₂ Hs2].
         pose proof Hs2 Hge Hged Hgok H2 H3 _ st Hrob Hread Hgst
@@ -1397,7 +1397,7 @@ Section Soundness.
               destruct Hl'l as [Hl'l | Hl'l]; subst;
               try rewrite PathMap.get_set_same in Hlt';
               try rewrite PathMap.get_set_same; eauto;
-              try some_inv; cbn;
+              try some_ok_inv; cbn;
               try rewrite PathMap.get_set_diff in Hlt' by assumption;
               try rewrite PathMap.get_set_diff by assumption; eauto.
           * clear Hdom; unfold gamma_var_val_typ in *.
@@ -1416,7 +1416,7 @@ Section Soundness.
               try rewrite PathMap.get_set_diff in Hlt' by assumption;
               try rewrite PathMap.get_set_diff in Hlsv' by assumption;
               cbn in *; unfold ok in *;
-              repeat some_inv;
+              repeat some_ok_inv;
               eauto 6 using uninit_sval_of_typ_val_typ.
         + destruct Hgst as [HΓₑ [Hgfdom Hgft]].
           unfold gamma_func_prop in *; split; auto.
@@ -1469,7 +1469,7 @@ Section Soundness.
                  destruct Hl'l as [Hl'l | Hl'l]; subst;
                  try rewrite PathMap.get_set_same in Hlt';
                  try rewrite PathMap.get_set_same; eauto;
-                 try some_inv; cbn;
+                 try some_ok_inv; cbn;
                  try rewrite PathMap.get_set_diff in Hlt' by assumption;
                  try rewrite PathMap.get_set_diff by assumption; eauto.
             -- clear Hdom; unfold gamma_var_val_typ in *.
@@ -1488,7 +1488,7 @@ Section Soundness.
                  try rewrite PathMap.get_set_diff in Hlt' by assumption;
                  try rewrite PathMap.get_set_diff in Hlsv' by assumption;
                  cbn in *; unfold ok in *;
-                 repeat some_inv; eauto.
+                 repeat some_ok_inv; eauto.
           * eapply exec_expr_call_False in H11; eauto. contradiction.
     Qed.
 

--- a/coq/lib/P4light/Semantics/Typing/Utility.v
+++ b/coq/lib/P4light/Semantics/Typing/Utility.v
@@ -514,13 +514,13 @@ Section Cast_Type_ind.
       end.
 End Cast_Type_ind.
 
-Ltac some_inv :=
+Ltac some_ok_inv :=
   match goal with
   | H: Some _ = Some _ |- _ => inversion H; subst; clear H
   | H: Ok _ = Ok _ |- _ => inversion H; subst; clear H
   end.
 
-Ltac match_some_inv :=
+Ltac match_some_ok_inv :=
   match goal with
   | H: match ?trm with Some _ => _ | None => _ end = Some _
     |- _ => destruct trm as [? |] eqn:? ; cbn in *;

--- a/coq/lib/Utils/Util/FunUtil.v
+++ b/coq/lib/Utils/Util/FunUtil.v
@@ -43,12 +43,14 @@ Ltac some_inv :=
   | H: Some _ = Some _ |- _ => inv H
   end.
 
-Ltac match_some_inv :=
+Tactic Notation "match_some_inv" "as" simple_intropattern(E) :=
   match goal with
   | H: match ?trm with Some _ => _ | None => _ end = Some _
-    |- _ => destruct trm as [? |] eqn:? ; cbn in *;
+    |- _ => destruct trm as [? |] eqn:E ; cbn in *;
           try discriminate
   end.
+
+Tactic Notation "match_some_inv" := match_some_inv as ?.
 
 (** * Utility Functions *)
 
@@ -59,8 +61,8 @@ Section MapProd.
   Definition map_fst '((a,c) : A * C) : B * C := (f a, c).
 
   Definition map_snd '((c,a) : C * A) : C * B := (c, f a).
-End MapProd.
-
+  
+  End MapProd.
 Fixpoint n_compose {A : Type} (n : nat) (f : A -> A) (x : A) : A :=
   match n with
   | O => x

--- a/coq/lib/Utils/Util/FunUtil.v
+++ b/coq/lib/Utils/Util/FunUtil.v
@@ -61,8 +61,8 @@ Section MapProd.
   Definition map_fst '((a,c) : A * C) : B * C := (f a, c).
 
   Definition map_snd '((c,a) : C * A) : C * B := (c, f a).
-  
-  End MapProd.
+End MapProd.
+
 Fixpoint n_compose {A : Type} (n : nat) (f : A -> A) (x : A) : A :=
   match n with
   | O => x


### PR DESCRIPTION
Adds more notations for option tactics and uses them in different interpreter soundness proofs.