### PR TITLE
Streamline Shifting Boilerplate in P4cub Lifting Pass

### DIFF
--- a/coq/extraction/dune
+++ b/coq/extraction/dune
@@ -33,10 +33,12 @@
   ToP4cub
   AST
   EquivDec
-  ToP4cub
-  ToGCL
-  GCL
-  Inline
+  Fin
+  VectorDef
+  Vector
+  VecUtil
+  ProdN
+  LiftList
   Statementize
   HoistNameless
   InferMemberTypes

--- a/coq/lib/P4cub/Semantics/Static/Auxiliary.v
+++ b/coq/lib/P4cub/Semantics/Static/Auxiliary.v
@@ -29,10 +29,10 @@ Ltac invert_type_lst_ok :=
 Section Lemmas.
   Local Hint Constructors lexpr_ok : core.
   
-  Lemma shift_lexpr_ok : forall sh e,
-      lexpr_ok e -> lexpr_ok (shift_exp sh e).
+  Lemma shift_lexpr_ok : forall c a e,
+      lexpr_ok e -> lexpr_ok (shift_exp c a e).
   Proof.
-    intros sh e h; induction h; unravel; auto.
+    intros c a e h; induction h; unravel; auto.
   Qed.
       
   Local Hint Resolve shift_lexpr_ok : core.
@@ -155,7 +155,7 @@ Section Lemmas.
   Lemma shift_type_exp : forall ts1 ts2 τ e,
       `⟨ Δ, ts1 ++ Γ ⟩ ⊢ e ∈ τ ->
       `⟨ Δ, ts1 ++ ts2 ++ Γ ⟩
-        ⊢ shift_exp (Shifter (length ts1) (length ts2)) e ∈ τ.
+        ⊢ shift_exp (length ts1) (length ts2) e ∈ τ.
   Proof using.
     intros ts1 ts2 t e h.
     (*generalize dependent ts2.*)
@@ -186,7 +186,7 @@ Section Lemmas.
   Lemma shift_type_arg : forall ts1 ts2 arg param,
       type_arg Δ (ts1 ++ Γ) arg param ->
       type_arg Δ (ts1 ++ ts2 ++ Γ)
-        (shift_arg (Shifter (length ts1) (length ts2)) arg) param.
+        (shift_arg (length ts1) (length ts2) arg) param.
   Proof using.
     unfold type_arg.
     intros ts1 ts2 arg param h; inv h; cbn; firstorder auto.

--- a/coq/lib/P4cub/Syntax/Shift.v
+++ b/coq/lib/P4cub/Syntax/Shift.v
@@ -1,31 +1,153 @@
 From Poulet4 Require Import
-     Utils.Util.FunUtil
-     P4cub.Syntax.AST P4cub.Syntax.CubNotations
-     P4cub.Syntax.IndPrincip.
+  Utils.Util.FunUtil
+  Utils.VecUtil
+  P4cub.Syntax.AST P4cub.Syntax.CubNotations
+  P4cub.Syntax.IndPrincip.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 Require Export Coq.Arith.Compare_dec.
-
-Record shifter : Set :=
-  Shifter { cutoff : nat; amt : nat }.
-
-Global Instance eta_shifter : Settable _ :=
-  settable! Shifter < cutoff ; amt >.
+From Equations Require Import Equations.
 
 Section Shift.
-  Variable s : shifter.
-  
-  Definition smother (n : nat) : shifter :=
-    s <| cutoff := n + s.(cutoff) |>.
+  Polymorphic Universe a.
+  Variable A : Type@{a}.
 
-  Definition boost (n : nat) : shifter :=
-    s <| amt := n + s.(amt) |>.
+  Polymorphic Definition shifter : Type@{a} := nat -> nat -> A -> A.
   
-  Definition shext : shifter :=
-    smother 1.
+  Polymorphic Class Shift : Type@{a} := {
+      shift : shifter;
+      shift_0 : forall c a, shift c 0 a = a;
+      shift_add : forall c m n a,
+        shift c m (shift c n a) = shift c (m + n) a
+    }.
+End Shift.
+
+Arguments shift {A}.
+Arguments shift_0 {A}.
+Arguments shift_add {A}.
+
+Section ShiftVec.
+  Import Vec.VectorNotations.
+  Local Open Scope vector_scope.
+  
+  Polymorphic Universe a.
+
+  Polymorphic Context {A : Type@{a}}.
+
+  Section shift.
+    Variables (sh : shifter A) (cutoff : nat).
+    
+    Section Shiftvec.
+      Variable amt : nat.
+      
+      Polymorphic Equations shift_vec : forall {n : nat}, Vec.t A n -> Vec.t A n := {
+          shift_vec []               := [];
+          shift_vec (Vec.cons a n v) := sh (cutoff + n)%nat amt a :: shift_vec v }.
+    End Shiftvec.
+    
+    Polymorphic Hypothesis sh_0 : forall c a, sh c 0 a = a.
+    
+    Polymorphic Lemma shift_vec_0 : forall {n} (v : Vec.t A n),
+        shift_vec 0 v = v.
+    Proof using A cutoff sh sh_0.
+      intros n v.
+      funelim (shift_vec 0 v).
+      - rewrite shift_vec_equation_1. reflexivity.
+      - rewrite shift_vec_equation_2.
+        rewrite sh_0. f_equal. assumption.
+    Qed.
+    
+    Polymorphic Hypothesis sh_add :
+      forall c m n a, sh c m (sh c n a) = sh c (m + n) a.
+    
+    Polymorphic Lemma shift_vec_add : forall m n {o} (v : Vec.t A o),
+        shift_vec m (shift_vec n v) = shift_vec (m + n) v.
+    Proof using A cutoff sh sh_add.
+      intros m n o v.
+      funelim (shift_vec n v).
+      - do 2 rewrite shift_vec_equation_1. reflexivity.
+      - do 3 rewrite shift_vec_equation_2. cbn.
+        rewrite sh_add. f_equal. auto.
+    Qed.
+  End shift.
+
+  Polymorphic Global Instance Shift_vec {n} `(SH : Shift A) : Shift (Vec.t A n) :=
+    { shift c a := shift_vec SH.(shift) c a (n:=n);
+      shift_0 c := shift_vec_0 SH.(shift) c SH.(shift_0);
+      shift_add c m q v := shift_vec_add SH.(shift) c SH.(shift_add) m q (o:=n) v
+    }.
+End ShiftVec.
+
+Section ShiftList.
+  Polymorphic Universe a.
+
+  Polymorphic Context {A : Type@{a}}.
+
+  Section shift.
+    Polymorphic Variables (sh : shifter A) (cutoff : nat).
+
+    Section Shiftlist.
+      Variable amt : nat.
+      
+      Polymorphic Fixpoint shift_list (l : list A) : list A :=
+        match l with
+        | [] => []
+        | h :: t => sh (cutoff + (length t)) amt h :: shift_list t
+        end.
+    End Shiftlist.
+
+    Polymorphic Lemma shift_list_length : forall n l,
+        length (shift_list n l) = length l.
+    Proof using.
+      intros n l; induction l as [| h t ih];
+        cbn; f_equal; auto.
+    Qed.
+
+    Polymorphic Local Hint Rewrite shift_list_length : core.
+    
+    Polymorphic Hypothesis sh_0 : forall c a, sh c 0 a = a.
+    
+    Polymorphic Lemma shift_list_0 : forall (l : list A),
+        shift_list 0 l = l.
+    Proof using A cutoff sh sh_0.
+      intro l; induction l as [| a l ih]; cbn; f_equal; auto.
+    Qed.
+
+    Polymorphic Hypothesis sh_add :
+      forall c m n a, sh c m (sh c n a) = sh c (m + n) a.
+    
+    Polymorphic Lemma shift_list_add : forall m n (l : list A),
+        shift_list m (shift_list n l) = shift_list (m + n) l.
+    Proof using A cutoff sh sh_add.
+      intros m n l.
+      induction l as [| a l ih]; cbn;
+        autorewrite with core;
+        f_equal; eauto.
+    Qed.
+  End shift.
+
+  Polymorphic Global Instance Shift_list `(SH : Shift A) : Shift (list A) :=
+    { shift := shift_list SH.(shift);
+      shift_0 c := shift_list_0 SH.(shift) c SH.(shift_0);
+      shift_add c := shift_list_add SH.(shift) c SH.(shift_add)
+    }.
+End ShiftList.
+
+Section Shift.
+  Variables cutoff amt : nat.
+
+  (** Updates cutoff. *)
+  (*Definition smother (n : nat) : nat :=
+    n + s.(cutoff)*)
+
+  (*Definition boost (n : nat) : shifter :=
+    s <| amt := n + s.(amt) |>.*)
+  
+  (*Definition shext : shifter :=
+    smother 1.*)
   
   Definition shift_var (x : nat) : nat :=
-    if le_lt_dec s.(cutoff) x then s.(amt) + x else x.
+    if le_lt_dec cutoff x then amt + x else x.
   
   Open Scope exp_scope.
   
@@ -82,40 +204,10 @@ Section Shift.
     end.
 End Shift.
 
-Section ShiftList.
-  Context {A : Set}.
-  Variable f : shifter -> A -> A.
-  Variable sh : shifter.
-
-  Fixpoint shift_list (l : list A) : list A :=
-    match l with
-    | [] => []
-    | h :: t => f (smother sh (length t)) h :: shift_list t
-    end.
-
-  Lemma shift_list_length : forall l,
-      length (shift_list l) = length l.
-  Proof using.
-    intro l; induction l as [| h t ih];
-      cbn; f_equal; auto.
-  Qed.
-End ShiftList.
-
-Lemma shift_exp_add : forall m n e,
-    shift_exp (Shifter 0 m) (shift_exp (Shifter 0 n) e) = shift_exp (Shifter 0 (m + n)) e.
-Proof.
-  intros m n e.
-  induction e using custom_exp_ind; unravel; f_equal; auto.
-  - unfold shift_var; cbn. lia.
-  - rewrite map_map.
-    apply map_ext_Forall.
-    assumption.
-Qed.
-
-Section Shift0.
+Section Shift.
   Variable c : nat.
 
-  Lemma shift_exp_0 : forall e, shift_exp (Shifter c 0) e = e.
+  Lemma shift_exp_0 : forall e, shift_exp c 0 e = e.
   Proof using.
     intro e.
     induction e using custom_exp_ind; unravel;
@@ -128,15 +220,25 @@ Section Shift0.
 
   Local Hint Rewrite shift_exp_0 : core.
 
-  Lemma shift_exp_0_map : forall es,
-      map (shift_exp (Shifter c 0)) es = es.
+  Lemma shift_exp_option_map_0 : forall oe,
+      option_map (shift_exp c 0) oe = oe.
+  Proof using.
+    intros [e |]; unravel; autorewrite with core; reflexivity.
+  Qed.
+
+  Local Hint Rewrite shift_exp_option_map_0 : core.
+  
+  Lemma shift_exp_map_0 : forall es,
+      map (shift_exp c 0) es = es.
   Proof using.
     intros es;
       induction es as [| e es ih]; unravel;
       autorewrite with core; f_equal; auto.
   Qed.
 
-  Lemma shift_arg_0 : forall arg, shift_arg (Shifter c 0) arg = arg.
+  Local Hint Rewrite shift_exp_map_0 : core.
+
+  Lemma shift_arg_0 : forall arg, shift_arg c 0 arg = arg.
   Proof using.
     intros []; unravel;
       autorewrite with core; reflexivity.
@@ -144,116 +246,214 @@ Section Shift0.
 
   Local Hint Rewrite shift_arg_0 : core.
 
-  Lemma shift_arg_0_map : forall args,
-      map (shift_arg (Shifter c 0)) args = args.
+  Lemma shift_arg_map_0 : forall args,
+      map (shift_arg c 0) args = args.
   Proof using.
     intros args;
       induction args as [| arg args ih];
       unravel; autorewrite with core;
       f_equal; auto.
   Qed.
+
+  Local Hint Rewrite shift_arg_map_0 : core.
   
-  Lemma shift_trans_0 : forall p, shift_trns (Shifter c 0) p = p.
+  Lemma shift_trns_0 : forall p, shift_trns c 0 p = p.
   Proof using.
     intros []; unravel;
       autorewrite with core; reflexivity.
   Qed.
-End Shift0.
+
+  Lemma shift_call_0 : forall cl, shift_call c 0 cl = cl.
+  Proof using.
+    intros []; unravel;
+      autorewrite with core; reflexivity.
+  Qed.
+
+  Variables m n : nat.
+
+  Lemma shift_exp_add : forall e,
+      shift_exp c m (shift_exp c n e)
+      = shift_exp c (m + n) e.
+  Proof using.
+    intro e.
+    induction e using custom_exp_ind; unravel; f_equal; auto.
+    - unfold shift_var; cbn.
+      repeat destruct_if; try lia.
+    - rewrite map_map.
+      apply map_ext_Forall.
+      assumption.
+  Qed.
+
+  Local Hint Rewrite shift_exp_add : core.
+  
+  Lemma shift_arg_add : forall arg,
+      shift_arg c m (shift_arg c n arg)
+      = shift_arg c (m + n) arg.
+  Proof using.
+    intros [e | e | e]; unravel; autorewrite with core; reflexivity.
+  Qed.
+
+  Local Hint Rewrite shift_arg_add : core.
+  
+  Lemma shift_trns_add : forall t,
+      shift_trns c m (shift_trns c n t)
+      = shift_trns c (m + n) t.
+  Proof using.
+    intros [ | ]; unravel; autorewrite with core; reflexivity.
+  Qed.
+
+  Lemma shift_exp_option_map_add : forall oe,
+      option_map (shift_exp c m) (option_map (shift_exp c n) oe)
+      = option_map (shift_exp c (m + n)) oe.
+  Proof using.
+    intros []; unravel;
+      autorewrite with core; reflexivity.
+  Qed.
+
+  Local Hint Rewrite shift_exp_option_map_add : core.
+  
+  Lemma shift_exp_map_add : forall es,
+      map (shift_exp c m) (map (shift_exp c n) es)
+      = map (shift_exp c (m + n)) es.
+  Proof using.
+    intros es;
+      induction es as [| e es ih]; unravel;
+      autorewrite with core; f_equal; auto.
+  Qed.
+
+  Local Hint Rewrite shift_exp_map_add : core.
+  
+  Lemma shift_arg_map_add : forall args,
+      map (shift_arg c m) (map (shift_arg c n) args)
+      = map (shift_arg c (m + n)) args.
+  Proof using.
+    intros args;
+      induction args as [| arg args ih]; unravel;
+      autorewrite with core; f_equal; auto.
+  Qed.
+
+  Lemma shift_call_add : forall cl,
+      shift_call c m (shift_call c n cl)
+      = shift_call c (m + n) cl.
+  Proof using.
+    intros []; unravel; autorewrite with core; reflexivity.
+  Qed.
+End Shift.
+
+Global Instance Shift_exp : Shift Exp.t := {
+    shift := shift_exp;
+    shift_0 := shift_exp_0;
+    shift_add := shift_exp_add
+  }.
+
+Global Instance Shift_arg : Shift (paramarg Exp.t Exp.t) := {
+    shift := shift_arg;
+    shift_0 := shift_arg_0;
+    shift_add := shift_arg_add
+  }.
+
+Global Instance Shift_trns : Shift Trns.t := {
+    shift := shift_trns;
+    shift_0 := shift_trns_0;
+    shift_add := shift_trns_add
+  }.
+
+Global Instance Shift_call : Shift Call.t := {
+    shift := shift_call;
+    shift_0 := shift_call_0;
+    shift_add := shift_call_add
+  }.
 
 Local Open Scope stm_scope.
 
 Fixpoint shift_stm
-  (sh : shifter) (s : Stm.t) : Stm.t :=
+  (c a : nat) (s : Stm.t) : Stm.t :=
   match s with
   | Stm.Skip
   | Stm.Exit => s
   | Stm.Ret oe
-    => Stm.Ret $ option_map (shift_exp sh) oe
+    => Stm.Ret $ option_map (shift_exp c a) oe
   | Stm.Trans e
-    => Stm.Trans $ shift_trns sh e
-  | e1 `:= e2 => shift_exp sh e1 `:= shift_exp sh e2
-  | Stm.SetValidity b e => Stm.SetValidity b $ shift_exp sh e
+    => Stm.Trans $ shift_trns c a e
+  | e1 `:= e2 => shift_exp c a e1 `:= shift_exp c a e2
+  | Stm.SetValidity b e => Stm.SetValidity b $ shift_exp c a e
   | Stm.Invoke e t
-    => Stm.Invoke (option_map (shift_exp sh) e) t
+    => Stm.Invoke (option_map (shift_exp c a) e) t
   | Stm.App fk args
-    => Stm.App (shift_call sh fk) $ map (shift_arg sh) args
+    => Stm.App (shift_call c a fk) $ map (shift_arg c a) args
   |`let og := te `in b
-    => `let og := map_sum id (shift_exp sh) te `in shift_stm (shext sh) b
-  | s₁ `; s₂ => shift_stm sh s₁ `; shift_stm sh s₂
+    => `let og := map_sum id (shift_exp c a) te `in shift_stm (S c) a b
+  | s₁ `; s₂ => shift_stm c a s₁ `; shift_stm c a s₂
   | `if e `then s₁ `else s₂
-    => `if shift_exp sh e `then shift_stm sh s₁ `else shift_stm sh s₂
+    => `if shift_exp c a e `then shift_stm c a s₁ `else shift_stm c a s₂
   end.
 
 Definition shift_ctrl
-  (sh : shifter) (d : Ctrl.t) : Ctrl.t :=
+  (c amt : nat) (d : Ctrl.t) : Ctrl.t :=
   match d with
-  | Ctrl.Var x te => Ctrl.Var x $ map_sum id (shift_exp sh) te
-  | Ctrl.Action a cps dps s => Ctrl.Action a cps dps $ shift_stm sh s
+  | Ctrl.Var x te => Ctrl.Var x $ map_sum id (shift_exp c amt) te
+  | Ctrl.Action a cps dps s => Ctrl.Action a cps dps $ shift_stm c amt s
   | Ctrl.Table t key argss def =>
       Ctrl.Table
-        t (map (fun '(e, mk) => (shift_exp sh e, mk)) key)
-        (map (fun '(a, args) => (a, map (shift_arg sh) args)) argss)
-        $ option_map (fun '(a, es) => (a, map (shift_exp sh) es)) def
+        t (map (fun '(e, mk) => (shift_exp c amt e, mk)) key)
+        (map (fun '(a, args) => (a, map (shift_arg c amt) args)) argss)
+        $ option_map (fun '(a, es) => (a, map (shift_exp c amt) es)) def
   end.
 
 Fixpoint shift_ctrls
-  (sh : shifter) (ds : list Ctrl.t) : list Ctrl.t :=
+  (c a : nat) (ds : list Ctrl.t) : list Ctrl.t :=
   match ds with
   | [] => []
   | Ctrl.Var x te as d :: ds =>
-      shift_ctrl sh d :: shift_ctrls (shext sh) ds
-  | d :: ds => shift_ctrl sh d :: shift_ctrls sh ds
+      shift_ctrl c a d :: shift_ctrls (S c) a ds
+  | d :: ds => shift_ctrl c a d :: shift_ctrls c a ds
   end.
-
-(*Definition shift_top_decl
-  (sh : shifter) (d : TopDecl.d) : TopDecl.d :=
-  match d with
-  | TopDecl.Instantiate
-  end.*)
 
 Local Close Scope stm_scope.
 
-Section Shift0.
+Section Shiftstm.
   Local Hint Rewrite shift_exp_0 : core.
-  Local Hint Rewrite shift_exp_0_map : core.
-
-  Lemma shift_explist_0 : forall es c,
-      shift_list shift_exp (Shifter c 0) es = es.
-  Proof.
-    intro es; induction es as [| e es ih];
-      intro c; unravel; unfold smother, RecordSet.set; cbn;
-      autorewrite with core; f_equal; auto.
-  Qed.
-  
-  Local Hint Rewrite shift_arg_0 : core.
-  Local Hint Rewrite shift_arg_0_map : core.
-  Local Hint Rewrite shift_trans_0 : core.
-
-  Lemma shift_call_0 : forall fk c,
-      shift_call (Shifter c 0) fk = fk.
-  Proof using.
-    intros [f ts [e |] | a es | ext mthd ts [e |] | ? ?] c; unravel;
-      autorewrite with core; reflexivity.
-  Qed.
-
+  Local Hint Rewrite shift_exp_map_0 : core.
+  Local Hint Rewrite shift_arg_map_0 : core.
+  Local Hint Rewrite shift_trns_0 : core.
   Local Hint Rewrite shift_call_0 : core.
+  Local Hint Rewrite shift_exp_option_map_0 : core.
   
-  Lemma shift_stm_0 : forall s c, shift_stm (Shifter c 0) s = s.
+  Lemma shift_stm_0 : forall c s, shift_stm c 0 s = s.
   Proof using.
-    intro s;
+    intros c s;
+      generalize dependent c;
       induction s;
-      intro c; unravel;
+      unravel;
+      intro c;
       autorewrite with core;
-      unfold shext, smother, RecordSet.set; unravel;
       f_equal; auto.
-    - destruct e; unravel;
-        autorewrite with core; reflexivity.
-    - destruct lhs; unravel;
-        autorewrite with core; reflexivity.
     - destruct init; unravel;
         autorewrite with core; reflexivity.
   Qed.
-End Shift0.
+
+  Local Hint Rewrite shift_exp_add : core.
+  Local Hint Rewrite shift_exp_map_add : core.
+  Local Hint Rewrite shift_arg_map_add : core.
+  Local Hint Rewrite shift_trns_add : core.
+  Local Hint Rewrite shift_call_add : core.
+  Local Hint Rewrite shift_exp_option_map_add : core.
+
+  Lemma shift_stm_add : forall c m n s,
+      shift_stm c m (shift_stm c n s) = shift_stm c (m + n) s.
+  Proof using.
+    intros c m n s.
+    generalize dependent c.
+    induction s; intro c; unravel; autorewrite with core; f_equal; auto.
+    destruct init; unravel; autorewrite with core; reflexivity.
+  Qed.
+
+  Global Instance Shift_stm : Shift Stm.t := {
+      shift := shift_stm;
+      shift_0 := shift_stm_0;
+      shift_add := shift_stm_add
+    }.
+End Shiftstm.
 
 (** Philip Wadler style de Bruijn shifts for expession variables. *)
 

--- a/coq/lib/P4cub/Syntax/Substitution.v
+++ b/coq/lib/P4cub/Syntax/Substitution.v
@@ -126,7 +126,7 @@ Section Sub.
     ; rtrns := option_map tsub_typ ret |}.
 
   Definition tsub_cparams : Top.constructor_params -> Top.constructor_params :=
-    List.map (FunUtil.map_snd tsub_insttyp).
+    List.map (prod_map_snd tsub_insttyp).
 End Sub.
 
 Definition tsub_method
@@ -159,13 +159,13 @@ Definition tsub_top (σ : nat -> Typ.t) (d : Top.t) : Top.t :=
   | Top.Extern ename tparams cparams expr_cparams methods =>
       let σ' := exts `^ tparams σ in
       let cparams' :=
-        List.map (FunUtil.map_snd $ tsub_insttyp σ') cparams in
+        List.map (prod_map_snd $ tsub_insttyp σ') cparams in
       let expr_cparams' :=
         map (tsub_typ σ') expr_cparams in
       let methods' := Field.map (tsub_method σ') methods in
       Top.Extern ename tparams cparams' expr_cparams' methods'
   | Top.Control cname cparams expr_cparams eparams params body apply_blk =>
-      let cparams' := map (FunUtil.map_snd $ tsub_insttyp σ) cparams in
+      let cparams' := map (prod_map_snd $ tsub_insttyp σ) cparams in
       let expr_cparams' :=
         map (tsub_typ σ) expr_cparams in
       let params' := map_snd (tsub_param σ) params in
@@ -173,7 +173,7 @@ Definition tsub_top (σ : nat -> Typ.t) (d : Top.t) : Top.t :=
       let apply_blk' := tsub_stm σ apply_blk in
       Top.Control cname cparams' expr_cparams' eparams params' body' apply_blk'
   | Top.Parser pn cps expr_cparams eps ps strt sts =>
-      let cps' := map (FunUtil.map_snd $ tsub_insttyp σ) cps in
+      let cps' := map (prod_map_snd $ tsub_insttyp σ) cps in
       let expr_cparams' :=
         map (tsub_typ σ) expr_cparams in
       let ps' := map_snd (tsub_param σ) ps in

--- a/coq/lib/P4cub/Transformations/Lifting/Lift.v
+++ b/coq/lib/P4cub/Transformations/Lifting/Lift.v
@@ -5,6 +5,7 @@ From Poulet4 Require Import
      P4cub.Syntax.CubNotations P4cub.Syntax.Shift
      P4cub.Syntax.IndPrincip
      P4cub.Transformations.Lifting.Statementize
+     P4cub.Transformations.Lifting.LiftList
      Utils.ForallMap.
 Import ListNotations Nat.
 From RecordUpdate Require Import RecordSet.
@@ -12,36 +13,6 @@ Import RecordSetNotations.
 
 Local Open Scope exp_scope.
 Local Open Scope stm_scope.
-
-Goal forall e es,
-    shift_pairs shift_exp [(e,es)] = [(e,es)].
-Proof.
-  intros; cbn; rewrite shift_exp_0 , shift_explist_0. reflexivity.
-Qed.
-
-Goal forall e1 e2 es1 es2,
-    shift_pairs shift_exp [(e2,es2);(e1,es1)]
-    = [(shift_exp (Shifter (length es2) (length es1)) e2,
-         shift_list shift_exp (Shifter 0 (length es1)) es2);
-       (shift_exp (Shifter 0 (length es2)) e1, es1)].
-Proof.
-  intros; unravel.
-  rewrite add_0_r, shift_explist_0, shift_exp_0.
-  reflexivity.
-Qed.
-
-Goal forall e1 e2 e3 es1 es2 es3,
-    shift_pairs shift_exp [(e3,es3);(e2,es2);(e1,es1)]
-    = [(shift_exp (Shifter (length es3) (length es2 + length es1)) e3,
-            shift_list shift_exp (Shifter 0 (length es2 + length es1)) es3);
-       (shift_exp (Shifter 0 (length es3)) (shift_exp (Shifter (length es2) (length es1)) e2),
-         shift_list shift_exp (Shifter 0 (length es1)) es2);
-       (shift_exp (Shifter 0 (length es3 + length es2)) e1, es1)].
-Proof.
-  intros; unravel.
-  rewrite add_0_r, shift_explist_0, shift_exp_0, shift_exp_add.
-  reflexivity.
-Qed.
 
 Inductive Lift_exp
   : Exp.t -> Exp.t -> list Exp.t -> Prop :=
@@ -79,9 +50,9 @@ Inductive Lift_exp
     (Exp.Index t e1 e2)
     (Exp.Index
        t
-       (shift_exp (Shifter 0 (length es2)) e1')
-       (shift_exp (Shifter (length es2) (length es1)) e2'))
-    (shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1)
+       (fst (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2)))
+       (snd (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2))))
+    (snd (shift_couple shift_exp shift_exp e1' e2' es1 es2) ++ es1)
 | Lift_bop t o e1 e2 e1' e2' es1 es2 :
   Lift_exp e1 e1' es1 ->
   Lift_exp e2 e2' es2 ->
@@ -90,16 +61,16 @@ Inductive Lift_exp
     (Exp.Var t "lifted_bop" 0)
     (Exp.Bop
        t o
-       (shift_exp (Shifter 0 (length es2)) e1')
-       (shift_exp (Shifter (length es2) (length es1)) e2')
-       :: shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1)
+       (fst (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2)))
+       (snd (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2)))
+       :: snd (shift_couple shift_exp shift_exp e1' e2' es1 es2) ++ es1)
 | Lift_lists ls es es' ess :
   Forall3 Lift_exp es es' ess ->
   Lift_exp
     (Exp.Lists ls es)
     (Exp.Var (typ_of_lists ls es) "lifted_lists" 0)
-    (Exp.Lists ls (map fst (shift_pairs shift_exp (combine es' ess)))
-       :: concat (map snd (shift_pairs shift_exp (combine es' ess)))).
+    (Exp.Lists ls (fst (shift_pairs shift_exp (combine es' ess)))
+       :: concat (snd (shift_pairs shift_exp (combine es' ess)))).
 
 Section LifteInduction.
   Variable P : Exp.t -> Exp.t -> list Exp.t -> Prop.
@@ -153,9 +124,9 @@ Section LifteInduction.
         (Exp.Index t e1 e2)
         (Exp.Index
            t
-           (shift_exp (Shifter 0 (length es2)) e1')
-           (shift_exp (Shifter (length es2) (length es1)) e2'))
-        (shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1).
+           (fst (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2)))
+           (snd (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2))))
+        (snd (shift_couple shift_exp shift_exp e1' e2' es1 es2) ++ es1).
   
   Hypothesis HLift_bop : forall t o e1 e2 e1' e2' es1 es2,
       Lift_exp e1 e1' es1 ->
@@ -167,9 +138,9 @@ Section LifteInduction.
         (Exp.Var t "lifted_bop" 0)
         (Exp.Bop
            t o
-           (shift_exp (Shifter 0 (length es2)) e1')
-           (shift_exp (Shifter (length es2) (length es1)) e2')
-           :: shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1).
+           (fst (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2)))
+           (snd (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2)))
+           :: snd (shift_couple shift_exp shift_exp e1' e2' es1 es2) ++ es1).
   
   Hypothesis HLift_lists : forall ls es es' ess,
       Forall3 Lift_exp es es' ess ->
@@ -177,8 +148,8 @@ Section LifteInduction.
       P
         (Exp.Lists ls es)
         (Exp.Var (typ_of_lists ls es) "lifted_lists" 0)
-        (Exp.Lists ls (map fst (shift_pairs shift_exp (combine es' ess)))
-           :: concat (map snd (shift_pairs shift_exp (combine es' ess)))).
+        (Exp.Lists ls (fst (shift_pairs shift_exp (combine es' ess)))
+           :: concat (snd (shift_pairs shift_exp (combine es' ess)))).
 
   Definition custom_Lift_exp_ind : forall e e' es,
       Lift_exp e e' es -> P e e' es :=
@@ -251,11 +222,11 @@ Variant Lift_call :
       (Call.Method ext mtd τs (Some e))
       (Call.Method ext mtd τs (Some e')) es
   | Lift_action_call a cargs cargs' ess :
-    Forall3 Lift_exp cargs cargs' ess ->
+    Lift_A_list shift_exp Lift_exp cargs cargs' ess ->
     Lift_call
       (Call.Action a cargs)
-      (Call.Action a (map fst (shift_pairs shift_exp (combine cargs' ess))))
-      (concat (map snd (shift_pairs shift_exp (combine cargs' ess))))
+      (Call.Action a cargs')
+      ess
   | Lift_inst_call x eargs :
     Lift_call (Call.Inst x eargs) (Call.Inst x eargs) [].
 
@@ -282,9 +253,9 @@ Inductive Lift_stm : Stm.t -> Stm.t -> Prop :=
   Lift_stm
     (e1 `:= e2)
     (Unwind
-       (shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1)
-       (shift_exp (Shifter 0 (length es2)) e1'
-          `:= shift_exp (Shifter (length es2) (length es1)) e2'))
+       (snd (shift_couple shift_exp shift_exp e1' e2' es1 es2) ++ es1)
+       (fst (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2))
+          `:= snd (fst (shift_couple shift_exp shift_exp e1' e2' es1 es2))))
 | Lift_setvalidity b e e' es :
   Lift_exp e e' es ->
   Lift_stm (Stm.SetValidity b e) (Unwind es (Stm.SetValidity b e'))
@@ -295,18 +266,17 @@ Inductive Lift_stm : Stm.t -> Stm.t -> Prop :=
   Lift_stm
     (Stm.Invoke (Some e) t)
     (Unwind es (Stm.Invoke (Some e') t))
-| Lift_app fk fk' fkes args args' argsess :
+| Lift_app fk fk' fkes args args' argses :
   Lift_call fk fk' fkes ->
-  Forall3 Lift_arg args args' argsess ->
+  Lift_A_list shift_arg Lift_arg args args' argses ->
   Lift_stm
     (Stm.App fk args)
     (Unwind
-       (shift_list shift_exp (Shifter 0 (length (concat argsess))) fkes
-          ++ concat (map snd (shift_pairs shift_arg (combine args' argsess))))
+       (snd (shift_couple (fun c a => map (shift_arg c a)) shift_call args' fk' argses fkes)
+          ++ argses)
        (Stm.App
-           (shift_call (Shifter (length fkes) (length (concat argsess))) fk')
-           (map (shift_arg $ Shifter 0 (length fkes))
-              (map fst (shift_pairs shift_arg (combine args' argsess))))))
+           (snd (fst (shift_couple (fun c a => map (shift_arg c a)) shift_call args' fk' argses fkes)))
+           (fst (fst (shift_couple (fun c a => map (shift_arg c a)) shift_call args' fk' argses fkes)))))
 | Lift_stmeq s1 s2 s1' s2' :
   Lift_stm s1 s1' ->
   Lift_stm s2 s2' ->
@@ -320,8 +290,8 @@ Inductive Lift_stm : Stm.t -> Stm.t -> Prop :=
     (Unwind
        es
        (`if e'
-          `then shift_stm (Shifter 0 (length es)) s1'
-          `else shift_stm (Shifter 0 (length es)) s2'))
+          `then shift_stm 0 (length es) s1'
+          `else shift_stm 0 (length es) s2'))
 | Lift_var_typ og t s s' :
   Lift_stm s s' ->
   Lift_stm
@@ -333,23 +303,7 @@ Inductive Lift_stm : Stm.t -> Stm.t -> Prop :=
     (`let og := inr e `in s)
     (Unwind
        es
-       (`let og := inr e' `in shift_stm (Shifter 1 (length es)) s')).
-
-Ltac destr_call_pair f :=
-  match goal with
-  | |- context [f ?a]
-    => destruct (f a) as [? ?] eqn:?; subst
-  end.
-    
-Ltac destr_lift_exp := destr_call_pair lift_exp.
-
-Ltac destr_lift_arg := destr_call_pair lift_arg.
-
-Ltac destr_lift_exp_list := destr_call_pair lift_exp_list.
-
-Ltac destr_lift_trns := destr_call_pair lift_trns.
-
-Ltac destr_lift_args := destr_call_pair lift_args.
+       (`let og := inr e' `in shift_stm 1 (length es) s')).
 
 Section Liftlift.
   Lemma Lift_lift_exp : forall e e' es,
@@ -358,13 +312,9 @@ Section Liftlift.
     intros e e' es h;
       induction h using custom_Lift_exp_ind;
       unravel;
-      repeat destr_lift_exp;
-      repeat match goal with
-        | h: (_, _) = (_, _) |- _ => inv h
-        end; auto.
-    destruct (split (shift_pairs shift_exp (map lift_exp es)))
-      as [es'' les] eqn:hsplit.
-    rewrite split_map in hsplit. inv hsplit.
+      repeat let_destr_pair;
+      repeat pair_fst_snd_eqns;
+      auto.
     enough (map lift_exp es = combine es' ess) as h.
     { do 5 f_equal; assumption. }
     assert (h12 : length es = length es') by eauto using Forall3_length12.
@@ -429,8 +379,7 @@ Section Liftlift.
       Forall3 Lift_exp es es' ess ->
       map lift_exp es = combine es' ess.
   Proof.
-    intros es es' ess h;
-      induction h; cbn; f_equal; auto.
+    refine (Forall3_LiftA_map_lifta _ _ _). auto.
   Qed.
 
   Ltac apply_Forall3_Lift_lift_exp :=
@@ -445,12 +394,11 @@ Section Liftlift.
       Lift_call fk fk' es ->
       lift_call fk = (fk', es).
   Proof.
-    intros fk fk' es h; inv h; unravel; auto.
+    intros fk fk' es h; inv h; cbn; auto.
+    let_destr_pair.
+    eapply Lift_A_list_lift_A_list with (lifta:=lift_exp) in H; auto.
     unfold lift_exp_list.
-    destruct (split (shift_pairs shift_exp $ map lift_exp cargs))
-      as [es les] eqn:hs.
-    rewrite split_map in hs; unravel in hs; inv hs.
-    auto.
+    pair_fst_snd_eqns. reflexivity.
   Qed.
 
   Local Hint Resolve Lift_lift_call : core.
@@ -467,8 +415,7 @@ Section Liftlift.
       Forall3 Lift_arg args args' ess ->
       map lift_arg args = combine args' ess.
   Proof.
-    intros es es' ess h;
-      induction h; cbn; f_equal; auto.
+    refine (Forall3_LiftA_map_lifta _ _ _). auto.
   Qed.
 
   Ltac apply_Forall3_Lift_lift_arg :=
@@ -482,25 +429,11 @@ Section Liftlift.
   Lemma Lift_lift_stm : forall s s',
       Lift_stm s s' -> lift_stm s = s'.
   Proof.
-    intros s s' h; induction h; unravel; subst; auto.
-    - apply_Lift_lift_call.
-      unfold lift_args.
-      destruct
-        (split (shift_pairs shift_arg $ map lift_arg args))
-        as [Args les] eqn:hsplit.
-      rewrite split_map in hsplit.
-      unravel in *; inv hsplit.
-      rewrite sublist.length_concat.
-      rewrite shift_pairs_inner_length.
-      rewrite <- sublist.length_concat.
-      assert (hlen12 : length args = length args')
-        by eauto using Forall3_length12.
-      assert (hlen13 : length args = length argsess)
-        by eauto using Forall3_length13.
-      assert (hlen23 : length args' = length argsess)
-        by eauto using Forall3_length23.
-      apply_Forall3_Lift_lift_arg.
-      repeat f_equal; auto using map_snd_combine.
+    intros s s' h; induction h; unravel; subst;
+      repeat let_destr_pair; auto.
+    apply Lift_lift_call in H.
+    apply Lift_A_list_lift_A_list with (lifta:=lift_arg) in H0; auto.
+    do 2 pair_fst_snd_eqns. reflexivity.
   Qed.
 End Liftlift.
 
@@ -511,44 +444,20 @@ Section liftLift.
     Lift_exp e (fst (lift_exp e)) (snd (lift_exp e)).
   Proof.
     intro e; induction e using custom_exp_ind; cbn;
-      repeat destr_lift_exp; cbn in *; auto.
+      repeat let_destr_pair; unravel; auto.
     - constructor. assumption.
-    - destruct
-        (split (shift_pairs shift_exp $ map lift_exp es)) as [es' les] eqn:hes.
-      rewrite split_map in hes.
-      unravel in *. inv hes.
-      assert (h: Forall3
-                   Lift_exp
-                   es
-                   (map fst (map lift_exp es))
-                   (map snd (map lift_exp es))).
-      { clear l.
-        rewrite Forall_forall in H.
-        rewrite Forall3_forall.
-        repeat rewrite map_length.
-        repeat split; try reflexivity.
-        intros n e e' exps he he' hes.
-        pose proof H _ (nth_error_In _ _ he) as h.
-        do 2 rewrite nth_error_map in he',hes.
-        rewrite he in he',hes.
-        cbn in he',hes.
-        inv he'; inv hes.
-        assumption. }
-      rewrite <- combine_map_fst_snd
-        with (l:=map lift_exp es). auto.
+    - rewrite <- combine_map_fst_snd with (l:=map lift_exp es).
+      constructor.
+      do 2 rewrite <- Forall3_map_23.
+      rewrite Forall3_Forall_123. assumption.
   Qed.
 
   Local Hint Resolve lift_Lift_exp : core.
-
-  Ltac solve_aux h :=
-    pose proof f_equal fst h as h1;
-    pose proof f_equal snd h as h2;
-    cbn in *; subst; auto.
   
   Corollary lift_Lift_exp_aux : forall e e' es,
       lift_exp e = (e', es) -> Lift_exp e e' es.
   Proof.
-    intros e e' es h; solve_aux h.
+    intros; pair_fst_snd_eqns; auto.
   Qed.
 
   Local Hint Resolve lift_Lift_exp_aux : core.
@@ -558,7 +467,7 @@ Section liftLift.
       Lift_arg arg (fst (lift_arg arg)) (snd (lift_arg arg)).
   Proof.
     intros [e | e | e]; unravel;
-      destr_lift_exp; cbn; auto.
+      let_destr_pair; cbn; auto.
   Qed.
 
   Local Hint Resolve lift_Lift_arg : core.
@@ -567,7 +476,7 @@ Section liftLift.
       lift_arg arg = (arg', es) ->
       Lift_arg arg arg' es.
   Proof.
-    intros arg arg' es h; solve_aux h.
+    intros; pair_fst_snd_eqns; auto.
   Qed.
 
   Local Hint Resolve lift_Lift_arg_aux : core.
@@ -577,7 +486,7 @@ Section liftLift.
       Lift_trns e (fst (lift_trns e)) (snd (lift_trns e)).
   Proof.
     intros []; unravel;
-      try destr_lift_exp; cbn; auto.
+      try let_destr_pair; cbn; auto.
   Qed.
 
   Local Hint Resolve lift_Lift_trns : core.
@@ -586,34 +495,18 @@ Section liftLift.
       lift_trns e = (e', es) ->
       Lift_trns e e' es.
   Proof.
-    intros e e' es h; solve_aux h.
+    intros; pair_fst_snd_eqns; auto.
   Qed.
 
   Local Hint Resolve lift_Lift_trns_aux : core.
   Local Hint Constructors Lift_call : core.
-
+  Local Hint Resolve lift_A_list_Lift_A_list : core.
+  
   Lemma lift_Lift_call : forall fk,
       Lift_call fk (fst (lift_call fk)) (snd (lift_call fk)).
   Proof.
     intros [f ts [e |] | a cs | extrn mthd ts [e |] | ? ?];
-      unravel; try destr_lift_exp; cbn; auto.
-    destr_lift_exp_list.
-    unfold lift_exp_list in Heqp.
-    destruct (split (shift_pairs shift_exp $ map lift_exp cs))
-      as [es ees] eqn:hsplit.
-    unravel in *.
-    rewrite split_map in hsplit.
-    inv hsplit; inv Heqp.
-    rewrite <- combine_map_fst_snd
-      with (l:=map lift_exp cs).
-    constructor.
-    rewrite Forall3_forall.
-    repeat rewrite map_length.
-    repeat (split; try reflexivity).
-    intros n e e' es he he' hes.
-    do 2 rewrite nth_error_map in he',hes.
-    rewrite he in he',hes. cbn in *.
-    inv he'; inv hes. auto.
+      unravel; try let_destr_pair; cbn; eauto using lift_A_list_Lift_A_list.
   Qed.
 
   Local Hint Resolve lift_Lift_call : core.
@@ -622,7 +515,7 @@ Section liftLift.
       lift_call fk = (fk', es) ->
       Lift_call fk fk' es.
   Proof.
-    intros fk fk' es h. solve_aux h.
+    intros; pair_fst_snd_eqns; auto.
   Qed.
 
   Local Hint Resolve lift_Lift_call_aux : core.
@@ -632,38 +525,13 @@ Section liftLift.
       Lift_stm s (lift_stm s).
   Proof.
     intro s; induction s; unravel;
-      try destr_lift_trns;
-      repeat destr_lift_exp;
-      try destr_call_pair lift_call;
-      try destr_lift_args;
-      auto.
+      repeat let_destr_pair;
+      eauto using lift_A_list_Lift_A_list.
     - destruct e as [e |];
-        try destr_lift_exp; auto.
-    - unfold lift_args in Heqp0.
-      destruct (split (shift_pairs shift_arg $ map lift_arg args))
-        as [args' les] eqn:hsplit.
-      unravel in *.
-      rewrite split_map in hsplit.
-      inv hsplit; inv Heqp0.
-      rewrite sublist.length_concat.
-      rewrite shift_pairs_inner_length.
-      rewrite <- sublist.length_concat.
-      rewrite <- combine_map_fst_snd
-        with (l := map lift_arg args) at 4.
-      rewrite <- combine_map_fst_snd
-        with (l := map lift_arg args) at 2.
-      constructor; auto.
-      rewrite Forall3_forall.
-      repeat rewrite map_length.
-      repeat (split; try reflexivity).
-      intros n arg arg' es harg harg' hes.
-      do 2 rewrite nth_error_map in harg',hes.
-      unfold Exp.arg in *.
-      rewrite harg in harg',hes; cbn in *.
-      inv harg'; inv hes. auto.
+        try let_destr_pair; auto.
     - destruct lhs as [e |];
-        try destr_lift_exp; eauto.
+        try let_destr_pair; eauto.
     - destruct init as [t | e];
-        try destr_lift_exp; auto.
+        try let_destr_pair; auto.
   Qed.
 End liftLift.

--- a/coq/lib/P4cub/Transformations/Lifting/LiftList.v
+++ b/coq/lib/P4cub/Transformations/Lifting/LiftList.v
@@ -1,0 +1,377 @@
+From Poulet4 Require Import
+     P4cub.Syntax.AST
+     P4cub.Syntax.Shift
+     Utils.ForallMap
+     Utils.VecUtil.
+From Equations Require Import Equations.
+Require Poulet4.Utils.ProdN.
+
+Section ShiftPairs.
+  Import ProdN.ProdNNotations.
+  Import Vec.VectorNotations.
+  Local Open Scope prodn_scope.
+
+  Polymorphic Universes a.
+  
+  Polymorphic Equations prodn_shift_pairs :
+    forall {n : nat} {AS : Vec.t Type@{a} n},
+      ProdN.t (Vec.map shifter AS) ->
+      ProdN.t AS -> Vec.t (list Exp.t) n ->
+      ProdN.t AS * Vec.t (list Exp.t) n := {
+      prodn_shift_pairs [] [] []%vector := ([], []%vector);
+      prodn_shift_pairs (f :: fs) (a :: p) (es :: ess)%vector :=
+        let m := vec_sum $ Vec.map (length (A:=Exp.t)) ess in
+        let '(p', v') := prodn_shift_pairs fs p ess in
+        (f (length es) m a ::
+           ProdN.map_uni2 0 (length es) fs p',
+          (shift_list shift_exp 0 m es :: v')%vector)
+    }.
+
+  Polymorphic Lemma prodn_shift_pairs_inner_length :
+    forall {n : nat} {AS : Vec.t Type@{a} n}
+      (fs : ProdN.t (Vec.map shifter AS))
+      (p : ProdN.t AS) (v : Vec.t (list Exp.t) n),
+      Vec.map (length (A:=Exp.t)) (snd (prodn_shift_pairs fs p v))
+      = Vec.map (length (A:=Exp.t)) v.
+  Proof using.
+    intros n AS fs p v.
+    funelim (prodn_shift_pairs fs p v); unravel in *.
+    - reflexivity.
+    - rewrite prodn_shift_pairs_equation_2. cbn.
+      let_destr_pair. unravel.
+      rewrite shift_list_length.
+      f_equal. assumption.
+  Qed.
+
+  Section ShiftCouple.
+    Polymorphic Context {A : Type@{a}}.
+    Variables fa : shifter A.
+
+    Polymorphic Definition vec_shift_pairs
+      {n : nat} (v : Vec.t A n) (ess : Vec.t (list Exp.t) n)
+      : Vec.t A n * Vec.t (list Exp.t) n :=
+      prod_map_fst ProdN.to_vec $
+        prodn_shift_pairs
+        (AS:=vec_rep n A) (ProdN.rep_param fa n) (ProdN.of_vec v) ess.
+
+    Polymorphic Lemma vec_shift_pairs_nil :
+      vec_shift_pairs []%vector []%vector = ([]%vector, []%vector).
+    Proof using.
+      unfold vec_shift_pairs; unravel.
+      rewrite (ProdN.of_vec_equation_1 (A:=A)).
+      rewrite prodn_shift_pairs_equation_1; cbn.
+      rewrite ProdN.to_vec_equation_1.
+      reflexivity.
+    Qed.
+
+    Polymorphic Lemma vec_shift_pairs_cons :
+      forall {n} a (v : Vec.t A n) es (ess : Vec.t (list Exp.t) n),
+        vec_shift_pairs (a :: v)%vector (es :: ess)%vector
+        = ((fa (length es) (vec_sum (Vec.map (length (A:=Exp.t)) ess)) a ::
+              Vec.map (fa 0 (length es)) (fst (vec_shift_pairs v ess)))%vector,
+            (shift_list shift_exp 0 (vec_sum (Vec.map (length (A:=Exp.t)) ess)) es
+               :: snd (vec_shift_pairs v ess))%vector).
+    Proof using.
+      intros n a v es ess.
+      unfold vec_shift_pairs; unravel.
+      rewrite ProdN.of_vec_equation_2, prodn_shift_pairs_equation_2.
+      let_destr_pair.
+      unravel. rewrite ProdN.to_vec_equation_2. f_equal. f_equal.
+      rewrite <- ProdN.to_vec_map_uni2.
+      reflexivity.
+    Qed.
+
+    Polymorphic Lemma vec_shift_pairs_inner_length : forall {n} (v : Vec.t A n) ess,
+        Vec.map (length (A:=Exp.t)) (snd (vec_shift_pairs v ess))
+        = Vec.map (length (A:=Exp.t)) ess.
+    Proof using.
+      intros n v ess.
+      unfold vec_shift_pairs; unravel.
+      rewrite snd_prod_map_fst, prodn_shift_pairs_inner_length.
+      reflexivity.
+    Qed.
+    
+    Polymorphic Definition shift_pairs
+      (l : list (A * list Exp.t)) : list A * list (list Exp.t) :=
+      let '(v,ess) := vec_unzip $ Vec.of_list l in
+      prod_map_fst Vec.to_list $ prod_map_snd Vec.to_list $ vec_shift_pairs v ess.
+
+    Polymorphic Lemma shift_pairs_nil : shift_pairs []%list = ([]%list,[]%list).
+    Proof using.
+      unfold shift_pairs; unravel.
+      rewrite vec_unzip_equation_1.
+      rewrite vec_shift_pairs_nil.
+      reflexivity.
+    Qed.
+
+    Polymorphic Lemma shift_pairs_cons : forall (a : A) es l,
+        shift_pairs ((a, es) :: l)%list
+        = ((fa (length es) (list_sum (map (length (A:=Exp.t)) (map snd l))) a ::
+              List.map (fa 0 (length es)) (fst (shift_pairs l)))%list,
+            (shift_list shift_exp 0 (list_sum (map (length (A:=Exp.t)) (map snd l))) es
+               :: snd (shift_pairs l))%list).
+    Proof using.
+      intros a es l.
+      unfold shift_pairs; unravel.
+      rewrite vec_unzip_equation_2.
+      repeat let_destr_pair.
+      rewrite vec_shift_pairs_cons. unravel.
+      do 2 rewrite Vec.to_list_cons.
+      rewrite Vec.to_list_map.
+      rewrite fst_prod_map_fst, snd_prod_map_fst,
+        fst_prod_map_snd, snd_prod_map_snd.
+      rewrite vec_unzip_correct; simpl.
+      rewrite Vec.map_map, List.map_map, vec_map_of_list, vec_sum_eq_rect.
+      unfold vec_sum,list_sum. rewrite vec_fold_right_of_list.
+      reflexivity.
+    Qed.
+
+    Polymorphic Lemma shift_pairs_lengths : forall l,
+        length (fst (shift_pairs l)) = length l
+        /\ length (snd (shift_pairs l)) = length l.
+    Proof using.
+      intro l; unfold shift_pairs; unravel.
+      let_destr_pair.
+      rewrite fst_prod_map_fst, snd_prod_map_fst,
+        fst_prod_map_snd, snd_prod_map_snd.
+      do 2 rewrite Vec.length_to_list.
+      split; reflexivity.
+    Qed.
+
+    Polymorphic Lemma shift_pairs_inner_length : forall l,
+        map (length (A:=Exp.t)) (snd (shift_pairs l))
+        = map (length (A:=Exp.t)) (map snd l).
+    Proof using.
+      intro l. unfold shift_pairs; unravel.
+      rewrite vec_unzip_correct, snd_prod_map_fst, snd_prod_map_snd.
+      rewrite map_to_list, vec_shift_pairs_inner_length.
+      do 2 rewrite <- map_to_list.
+      rewrite Vec.to_list_of_list_opp. reflexivity.
+    Qed.
+
+    Polymorphic Variable lifta : A -> A * list Exp.t.
+    
+    Polymorphic Definition lift_A_list (l : list A) : list A * list Exp.t :=
+      prod_map_snd (List.concat (A:=Exp.t)) $ shift_pairs $ List.map lifta l.
+
+    Polymorphic Definition lift_A_list_length : forall l,
+        length (fst (lift_A_list l)) = length l.
+    Proof using.
+      intro l; unfold lift_A_list; unravel.
+      rewrite fst_prod_map_snd,
+        (proj1 (shift_pairs_lengths (map lifta l))),
+        map_length.
+      reflexivity.
+    Qed.
+
+    Polymorphic Variable LiftA : A -> A -> list Exp.t -> Prop.
+    
+    Polymorphic Definition Lift_A_list (l l' : list A) (es : list Exp.t) : Prop :=
+      exists la ess,
+        Forall3 LiftA l la ess
+        /\ l' = fst (shift_pairs (combine la ess))
+        /\ es = List.concat (A:=Exp.t) (snd (shift_pairs (combine la ess))).
+
+    Polymorphic Hypothesis LiftA_lifta : forall a a' es,
+        LiftA a a' es -> lifta a = (a', es).
+
+    Polymorphic Remark Forall3_LiftA_map_lifta : forall l l' ess,
+        Forall3 LiftA l l' ess -> map lifta l = combine l' ess.
+    Proof using A LiftA LiftA_lifta lifta.
+      intros l l' ess h.
+      induction h; cbn; f_equal; auto.
+    Qed.
+    
+    Polymorphic Lemma Lift_A_list_lift_A_list : forall l l' es,
+        Lift_A_list l l' es -> lift_A_list l = (l',es).
+    Proof using A LiftA LiftA_lifta lifta.
+      intros l l' es (la & ess & hLift & hl' & hes'); subst.
+      unfold lift_A_list; unravel.
+      apply Forall3_LiftA_map_lifta in hLift.
+      rewrite hLift.
+      apply injective_projections.
+      - rewrite fst_prod_map_snd; reflexivity.
+      - rewrite snd_prod_map_snd; reflexivity.
+    Qed.
+
+    Polymorphic Hypothesis lifta_LiftA : forall a,
+        LiftA a (fst (lifta a)) (snd (lifta a)).
+
+    Polymorphic Lemma lift_A_list_Lift_A_list : forall l,
+        Lift_A_list l (fst (lift_A_list l)) (snd (lift_A_list l)).
+    Proof using A LiftA fa lifta lifta_LiftA.
+      intro l. unfold Lift_A_list.
+      exists (map fst (map lifta l)), (map snd (map lifta l)).
+      rewrite sublist.combine_eq.
+      split.
+      - do 2 rewrite <- Forall3_map_23.
+        rewrite Forall3_Forall_123,Forall_forall.
+        eauto.
+      - unfold lift_A_list; unravel.
+        rewrite fst_prod_map_snd, snd_prod_map_snd.
+        split; reflexivity.
+    Qed.
+    
+    Polymorphic Context {B : Type@{a}}.
+    Variable fb : shifter B.
+    
+    Polymorphic Hypothesis fa_0 : forall c a, fa c 0 a = a.
+    Polymorphic Hypothesis fb_0 : forall c b, fb c 0 b = b.
+
+    Local Hint Rewrite shift_exp_0 : core.
+    Local Hint Resolve shift_exp_0 : core.
+    Local Hint Rewrite PeanoNat.Nat.add_0_r : core.
+    Local Hint Rewrite fa_0 : core.
+    Local Hint Rewrite fb_0 : core.
+    Local Hint Rewrite (@shift_list_0 Exp.t) : core.
+    
+    Polymorphic Lemma prodn_shift_pairs_single : forall a es,
+        prodn_shift_pairs (AS:=[A]%vector) (fa :: []) (a :: []) [es]%vector
+        = (a :: [],[es]%vector).
+    Proof using A fa fa_0.
+      intros; cbn.
+      rewrite prodn_shift_pairs_equation_2; unravel.
+      rewrite prodn_shift_pairs_equation_1; unravel.
+      rewrite ProdN.map_uni2_equation_1.
+      autorewrite with core. cbn.
+      rewrite shift_list_0 by eauto.
+      reflexivity.
+    Qed.
+
+    Polymorphic Lemma prodn_shift_pairs_couple :
+      forall a b esa esb,
+        prodn_shift_pairs
+          (AS := [B; A]%vector)
+          (fb :: fa :: []) (b :: a :: []) [esb ; esa]%vector
+        = (fb (length esb) (length esa) b :: fa 0 (length esb) a :: [],
+            [shift_list shift_exp 0 (length esa) esb; esa]%vector).
+    Proof using A fa fb fa_0 fb_0.
+      intros a b esa esb.
+      rewrite prodn_shift_pairs_equation_2. cbn.
+      rewrite prodn_shift_pairs_single.
+      autorewrite with core. f_equal.
+    Qed.
+
+    Polymorphic Definition shift_couple
+      (a : A) (b : B) (esa esb : list Exp.t) : A * B * list Exp.t :=
+      let '(ba, ess) :=
+        prodn_shift_pairs
+          (AS := [B; A]%vector)
+          (fb :: fa :: [])
+          (b :: a :: [])
+          [esb ; esa]%vector in
+      (ProdN.nth (Fin.FS Fin.F1) ba,
+        ProdN.hd ba, Vec.hd ess).
+
+    Polymorphic Lemma shift_couple_length : forall a b esa esb,
+        length (snd (shift_couple a b esa esb)) = length esb.
+    Proof using.
+      intros a b esa esb.
+      unfold shift_couple.
+      pose proof
+        prodn_shift_pairs_inner_length
+        (AS := [B; A]%vector)
+        (fb :: fa :: [])
+        (b :: a :: [])
+        [esb ; esa]%vector as h.
+      let_destr_pair.
+      cbn in *.
+      apply f_equal with (f:=Vec.hd) in h.
+      rewrite vec_hd_map in h.
+      assumption.
+    Qed.
+    
+    Polymorphic Lemma shift_couple_spec : forall a b esa esb,
+        shift_couple a b esa esb
+        = (fa 0 (length esb) a,
+            fb (length esb) (length esa) b,
+              shift_list shift_exp 0 (length esa) esb).
+    Proof using A fa fb fa_0 fb_0.
+      intros a b esa esb.
+      unfold shift_couple.
+      rewrite prodn_shift_pairs_couple.
+      unravel. auto.
+    Qed.
+
+    Context {C : Type@{a}}.
+    Variable fc : shifter C.
+
+    Polymorphic Hypothesis fc_0 : forall ct c, fb ct 0 c = c.
+    
+    Polymorphic Hypothesis fa_add
+      : forall m n a, fa 0 m (fa 0 n a) = fa 0 (m + n) a.
+
+    Local Hint Rewrite fc_0 : core.
+    Local Hint Rewrite fa_add : core.
+    
+    Polymorphic Lemma prodn_shift_pairs_triple :
+      forall a b c esa esb esc,
+        prodn_shift_pairs
+          (AS:=[C; B; A]%vector)
+          (fc :: fb :: fa :: [])
+          (c :: b :: a :: [])
+          [esc; esb; esa]%vector
+        = (fc (length esc) (length esb + length esa) c ::
+             fb 0 (length esc) (fb (length esb) (length esa) b) ::
+             fa 0 (length esc + length esb) a :: [],
+            [shift_list shift_exp 0 (length esb + length esa) esc;
+             shift_list shift_exp 0 (length esa) esb; esa]%vector).
+    Proof using A B C fa fa_0 fa_add fb fb_0 fc.
+      intros a b c esa esb esc.
+      rewrite prodn_shift_pairs_equation_2. cbn.
+      rewrite prodn_shift_pairs_couple.
+      rewrite ProdN.map_uni2_equation_2
+        with (v := [A]%vector) (f := fb) (fs := fa :: []).
+      rewrite ProdN.map_uni2_equation_2  with (v := []%vector) (f := fa) (fs := []).
+      rewrite ProdN.map_uni2_equation_1.
+      autorewrite with core. reflexivity.
+    Qed.
+
+    Polymorphic Definition shift_triple
+      (a : A) (b : B) (c : C) (esa esb esc : list Exp.t)
+      : A * B * C * list Exp.t * list Exp.t :=
+      let '(cba, ess) :=
+        prodn_shift_pairs
+          (AS:=[C; B; A]%vector)
+          (fc :: fb :: fa :: [])
+          (c :: b :: a :: [])
+          [esc; esb; esa]%vector in
+      (ProdN.nth (Fin.FS $ Fin.FS Fin.F1) cba,
+        ProdN.nth (Fin.FS Fin.F1) cba,
+        ProdN.hd cba, Vec.nth ess (Fin.FS Fin.F1), Vec.hd ess).
+
+    Polymorphic Lemma shift_triple_lengths : forall a b c esa esb esc,
+        length (snd (fst (shift_triple a b c esa esb esc))) = length esb
+        /\ length (snd (shift_triple a b c esa esb esc)) = length esc.
+    Proof using.
+      intros a b c esa esb esc.
+      unfold shift_triple.
+      pose proof prodn_shift_pairs_inner_length
+        (AS:=[C; B; A]%vector)
+        (fc :: fb :: fa :: [])
+        (c :: b :: a :: [])
+        [esc; esb; esa]%vector as h.
+      let_destr_pair.
+      pose proof f_equal Vec.hd h as hhd.
+      pose proof f_equal (fun v => Vec.nth v (Fin.FS Fin.F1)) h as hnth.
+      cbn in *. rewrite vec_hd_map in hhd.
+      rewrite Vec.nth_map with (p2:=Fin.FS Fin.F1) in hnth by reflexivity.
+      split; assumption.
+    Qed.
+    
+    Polymorphic Lemma shift_triple_spec :
+      forall a b c esa esb esc,
+        shift_triple a b c esa esb esc
+        = (fa 0 (length esc + length esb) a,
+            fb 0 (length esc) (fb (length esb) (length esa) b),
+            fc (length esc) (length esb + length esa) c,
+            shift_list shift_exp 0 (length esa) esb,
+            shift_list shift_exp 0 (length esb + length esa) esc).
+    Proof using A B C fa fa_0 fa_add fb fb_0 fc.
+      intros a b c esa esb esc.
+      unfold shift_triple.
+      rewrite prodn_shift_pairs_triple.
+      unravel. auto.
+    Qed.
+  End ShiftCouple.
+End ShiftPairs.

--- a/coq/lib/P4cub/Transformations/Lifting/LiftSpec.v
+++ b/coq/lib/P4cub/Transformations/Lifting/LiftSpec.v
@@ -3,8 +3,12 @@ Require Export Coq.Lists.List
   Poulet4.Utils.ForallMap
   Poulet4.P4cub.Syntax.Syntax
   Poulet4.P4cub.Syntax.Shift
-  Poulet4.P4cub.Transformations.Lifting.Statementize.
+  Poulet4.P4cub.Transformations.Lifting.Statementize
+  Poulet4.P4cub.Transformations.Lifting.LiftList
+  Poulet4.Utils.VecUtil.
 Import ListNotations Nat.
+Require Poulet4.Utils.ProdN.
+From Equations Require Import Equations.
 
 Section RelateDeclList.
   Polymorphic Universes a b.
@@ -39,111 +43,290 @@ Section RelateDeclList.
   Qed.
 End RelateDeclList.
 
-Section RelateExprDeclList.
-  Polymorphic Universe a.
-  Polymorphic Context {A : Type@{a}}.
-  Polymorphic Variable R : list A -> Exp.t -> A -> Prop.
-  Polymorphic Variable l : list A.
-
-  Polymorphic Hypothesis shift_exp_preserves_R : forall as1 as2 as3 a e,
-      R (as1 ++ as3) e a ->
-      R (as1 ++ as2 ++ as3) (shift_exp (Shifter (length as1) (length as2)) e) a.
+Section RelateDeclListApp.
+  Polymorphic Universes a b.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}}.
 
   Local Hint Constructors relate_decl_list : core.
   
-  Polymorphic Lemma relate_decl_list_app : forall es1 es2 as1 as2,
-      relate_decl_list R l es1 as1 ->
-      relate_decl_list R l es2 as2 ->
-      relate_decl_list R l (shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1) (as2 ++ as1).
-  Proof using A R l shift_exp_preserves_R.
-    intros es1 es2 as1 as2 h1 h2.
+  Polymorphic Lemma pred_decl_list : forall (P : A -> Prop) (b : B) (bs : list B) (l : list A),
+      relate_decl_list
+        (fun _ a _ => P a) bs l (repeat b (length l))
+      <-> Forall P l.
+  Proof using.
+    intros P b bs l; split; intros h;
+      induction l as [| a l ih]; inv h; cbn; auto.
+  Qed.
+  
+  Polymorphic Variable R : list A -> B -> A -> Prop.
+  Polymorphic Variable shiftB : shifter B.
+
+  Polymorphic Hypothesis shift_preserves_R : forall as1 as2 as3 a b,
+      R (as1 ++ as3) b a ->
+      R (as1 ++ as2 ++ as3) (shiftB (length as1) (length as2) b) a.
+
+  Polymorphic Variable l : list A.
+
+  Polymorphic Lemma relate_decl_list_app : forall bs1 bs2 as1 as2,
+      relate_decl_list R l bs1 as1 ->
+      relate_decl_list R l bs2 as2 ->
+      relate_decl_list R l (shift_list shiftB 0 (length bs1) bs2 ++ bs1) (as2 ++ as1).
+  Proof using A B R shift_preserves_R l.
+    intros bs1 bs2 as1 as2 h1 h2.
     generalize dependent as1.
-    generalize dependent es1.
-    induction h2; intros es1 as1 h1; cbn; auto.
-    unfold smother, RecordSet.set; cbn.
-    rewrite add_0_r.
+    generalize dependent bs1.
+    induction h2; intros bs1 as1 h1; cbn; auto.
     constructor; auto. rewrite <- app_assoc.
     rewrite (relate_decl_list_length _ _ _ _ h1).
     rewrite (relate_decl_list_length _ _ _ _ h2).
     eauto.
   Qed.
+End RelateDeclListApp.
 
-  Local Hint Resolve relate_decl_list_app : core.
+Section RelateDeclListProdN.
+  Polymorphic Universes a b.
+  Polymorphic Context {A : Type@{a}}.
+  Polymorphic Variable R_exp : list A -> Exp.t -> A -> Prop.
+  Polymorphic Hypothesis shift_preserves_R_exp : forall as1 as2 as3 a e,
+      R_exp (as1 ++ as3) e a ->
+      R_exp (as1 ++ as2 ++ as3) (shift_exp (length as1) (length as2) e) a.
+  Polymorphic Variable l : list A.
   
-  Polymorphic Lemma shift_pairs_relate_snd : forall ess ass,
-      Forall2 (relate_decl_list R l) (map snd ess) ass ->
-      relate_decl_list R l
-        (concat (map snd (shift_pairs shift_exp ess)))
-        (concat ass).
-  Proof using A R l shift_exp_preserves_R.
-    intros ess vss h.
-    remember (map snd ess) as sess eqn:hess.
+  (*Polymorphic Lemma relate_decl_prodn_shift_pairs :
+    forall {n} {v : Vec.t Type@{b} n}
+      (shifts : ProdN.t (Vec.map shifter v))
+      (Rs : ProdN.t (Vec.map (fun B => list A -> B -> A -> Prop) v)),
+      (forall (as1 as2 as3 : list A) (p : ProdN.t) (va : Vec.t A n),
+          ProdN.relate_uni1 (as1 ++ as3) Rs p va ->
+          ProdN.relate_uni1
+            (as1 ++ as2 ++ as3)
+            Rs (ProdN.map_uni2 (length as1) (length as2) shiftB p) va) ->
+      forall (p : ProdN.t v) (ess : Vec.t (list Exp.t) n) (vas ass : Vec.t (list A) n),
+        ProdN.relate_uni1
+        ProdN.relate_middle R (Vec.map (fun a => a ++ l) vas p vs ->
+        Vec.Forall2 (relate_decl_list R_exp l) ess ass ->
+        relate_decl_list R l
+          (Vec.concat (snd (prodn_shift_pairs shifts p ess)))
+          (Vec.concat ass).*)
+      
+End RelateDeclListProdN.
+
+Section RelateExprDeclList.
+  Import List.ListNotations.
+  Import Vec.VectorNotations.
+  
+  Polymorphic Universes a b.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}}.
+  Polymorphic Variable shiftB : shifter B.
+  Polymorphic Variable R : list A -> B -> A -> Prop.
+  Polymorphic Hypothesis shift_preserves_R : forall as1 as2 as3 b a,
+      R (as1 ++ as3) b a ->
+      R (as1 ++ as2 ++ as3) (shiftB (length as1) (length as2) b) a.
+
+  Local Hint Constructors Vec.Forall2 : core.
+  
+  Polymorphic Lemma shift_preserves_R_vec_Forall2 :
+    forall (as1 as2 as3 : list A) {n} (bs : Vec.t B n) (vs : Vec.t A n),
+      Vec.Forall2 (R (as1 ++ as3)) bs vs ->
+      Vec.Forall2 (R (as1 ++ as2 ++ as3)) (Vec.map (shiftB (length as1) (length as2)) bs) vs.
+  Proof using A B R shiftB shift_preserves_R.
+    intros as1 as2 as3 n bs vs h.
+    depind h; cbn; auto.
+  Qed.
+
+  Local Hint Resolve shift_preserves_R_vec_Forall2 : core.
+  Local Hint Resolve Peano_dec.UIP_nat : core.
+
+  Polymorphic Lemma shift_preserves_R_Forall2 :
+    forall (as1 as2 as3 : list A) (bs : list B) (vs : list A),
+      Forall2 (R (as1 ++ as3)) bs vs ->
+      Forall2 (R (as1 ++ as2 ++ as3)) (List.map (shiftB (length as1) (length as2)) bs) vs.
+  Proof using A B R shiftB shift_preserves_R.
+    intros as1 as2 as3 bs vs h.
+    rewrite Forall2_flip in h |- *.
+    pose proof sublist.Forall2_length h as hlen.
+    symmetry in hlen.
+    rewrite <- vec_Forall2_of_list with (hlen:=hlen) in h.
+    pose proof map_length (shiftB (length as1) (length as2)) bs as hlenmap.
+    rewrite hlen in hlenmap.
+    rewrite <- vec_Forall2_of_list with (hlen:=hlenmap).
+    rewrite <- vec_Forall2_flip in h |- *.
+    rewrite vec_of_list_map.
+    rewrite rew_compose.
+    rewrite map_subst.
+    replace (Logic.eq_trans (Logic.eq_sym (my_map_length (shiftB (length as1) (length as2)) bs)) hlenmap)
+      with hlen by auto. auto.
+  Qed.
+  
+  Polymorphic Variable R_exp : list A -> Exp.t -> A -> Prop.
+  Polymorphic Hypothesis shift_preserves_R_exp : forall as1 as2 as3 e a,
+      R_exp (as1 ++ as3) e a ->
+      R_exp (as1 ++ as2 ++ as3) (shift_exp (length as1) (length as2) e) a.
+  Polymorphic Variable l : list A.
+  
+  Local Hint Resolve relate_decl_list_app : core.
+  Local Hint Constructors relate_decl_list : core.
+  
+  Polymorphic Lemma vec_shift_pairs_relate_snd :
+    forall {n} (bs : Vec.t B n) (ess : Vec.t (list Exp.t) n) (ass : Vec.t (list A) n),
+      Vec.Forall2 (relate_decl_list R_exp l) ess ass ->
+      relate_decl_list R_exp l
+        (vec_concat_list (snd (vec_shift_pairs shiftB bs ess)))
+        (vec_concat_list ass).
+  Proof using A B shiftB R_exp l shift_preserves_R_exp.
+    intros n bs ess ass h; generalize dependent bs.
+    depind h; intro bs; depelim bs.
+    - rewrite vec_shift_pairs_nil; cbn; auto.
+    - rewrite vec_shift_pairs_cons; cbn.
+      pose proof IHh bs as ih; clear IHh.
+      assert (vec_sum (Vec.map (length (A:=Exp.t)) v1)
+              = length (vec_concat_list (snd (vec_shift_pairs shiftB bs v1)))) as hlen.
+      { unfold vec_sum.
+        rewrite length_vec_concat_list.
+        rewrite vec_shift_pairs_inner_length.
+        reflexivity. }
+      rewrite hlen; auto.
+  Qed.
+
+  Polymorphic Lemma vec_shift_pairs_relate_fst :
+    forall {n} (bs : Vec.t B n) (ess : Vec.t (list Exp.t) n) (vs : Vec.t A n) (ass : Vec.t (list A) n),
+      vec_Forall3 (fun vs e v => R (vs ++ l) e v) ass bs vs ->
+      Vec.Forall2 (relate_decl_list R_exp l) ess ass ->
+      Vec.Forall2
+        (R (vec_concat_list ass ++ l))
+        (fst (vec_shift_pairs shiftB bs ess)) vs.
+  Proof using A B R R_exp l shiftB shift_preserves_R shift_preserves_R_exp.
+    intros n bs ess vs ass hf3 hf2.
     generalize dependent ess.
-    induction h; intros [| [e es] ess] hess; inv hess;
-      unravel in *; auto.
-    pose proof IHh ess ltac:(auto) as ih; clear IHh.
-    rewrite map_snd_map, map_id.
-    assert (list_sum (map (length (A:=Exp.t)) (map snd ess))
-            = length (concat (map snd (shift_pairs shift_exp ess)))) as hlen.
-    { unfold list_sum.
-      rewrite sublist.length_concat.
-      rewrite shift_pairs_inner_length.
-      reflexivity. }
-    rewrite hlen. auto.
+    depind hf3; intros ess hf2; depelim hf2.
+    - rewrite vec_shift_pairs_nil; cbn; auto.
+    - rewrite vec_shift_pairs_cons; simpl.
+      rewrite vec_concat_list_cons.
+      rewrite <- app_assoc.
+      constructor; auto.
+      + unfold vec_sum.
+        apply vec_shift_pairs_relate_snd with (bs:=vb) in hf2.
+        apply relate_decl_list_length in H0,hf2.
+        rewrite length_vec_concat_list in hf2.
+        rewrite vec_shift_pairs_inner_length in hf2.
+        rewrite <- length_vec_concat_list in hf2.
+        rewrite <- length_vec_concat_list,hf2,H0. auto.
+      + apply relate_decl_list_length in H0.
+        rewrite H0.
+        apply IHhf3 in hf2.
+        apply shift_preserves_R_vec_Forall2 with
+          (as1 := []%list) (as2 := a) (as3 := (vec_concat_list va ++ l)%list).
+        assumption.
+  Qed.
+  
+  Polymorphic Lemma shift_pairs_relate_snd : forall (ess : list (B * list Exp.t)) ass,
+      Forall2 (relate_decl_list R_exp l) (map snd ess) ass ->
+      relate_decl_list R_exp l
+        (concat (snd (shift_pairs shiftB ess)))
+        (concat ass).
+  Proof using A B shiftB R_exp l shift_preserves_R_exp.
+    intros ess ass h.
+    unfold shift_pairs; unravel.
+    let_destr_pair.
+    rewrite snd_prod_map_fst,snd_prod_map_snd.
+    rewrite vec_unzip_correct; cbn.
+    rewrite <- Vec.to_list_of_list_opp with (l:=ass).
+    do 2 rewrite concat_vec_to_list.
+    pose proof sublist.Forall2_length h as hlen.
+    rewrite map_length in hlen.
+    symmetry in hlen.
+    unfold vec_concat_list at 2.
+    rewrite <- vec_fold_right_eq_rect with (nm:=hlen) (v:=Vec.of_list ass).
+    apply vec_shift_pairs_relate_snd.
+    rewrite vec_map_of_list, vec_Forall2_eq_rect_l, rew_compose, vec_Forall2_of_list.
+    assumption.
   Qed.
 
   Polymorphic Lemma shift_pairs_relate_fst : forall es ess vs vss,
       length es = length ess ->
       Forall3 (fun vs e v => R (vs ++ l) e v) vss es vs ->
-      Forall2 (relate_decl_list R l) ess vss ->
+      Forall2 (relate_decl_list R_exp l) ess vss ->
       Forall2
         (R (concat vss ++ l))
-        (map fst (shift_pairs shift_exp (combine es ess))) vs.
-  Proof using A R l shift_exp_preserves_R.
-    intros es ess vs vss hl hF3.
-    generalize dependent ess.
-    induction hF3; intros [| E ess] hl hF2;
-      inv hF2; unravel in *; auto; try discriminate.
-    inv hl.
-    rewrite <- app_assoc.
-    rewrite map_snd_combine by assumption.
-    rewrite map_fst_map.
-    unfold list_sum.
-    rewrite <- sublist.length_concat.
-    assert (hlen : length (concat ess) = length (concat ts)).
-    { rewrite <- map_snd_combine with (us := us) (vs := ess)
-        in H5 by assumption.
-      apply shift_pairs_relate_snd in H5.
-      apply relate_decl_list_length in H5.
-      rewrite sublist.length_concat in H5 at 1.
-      rewrite shift_pairs_inner_length in H5.
-      rewrite <- sublist.length_concat in H5.
-      rewrite <- H5.
-      rewrite map_snd_combine by eauto.
-      reflexivity. }
-    rewrite hlen.
-    rewrite (relate_decl_list_length _ _ _ _ H3).
-    constructor; auto using shift_exp_preserves_R.
-    pose proof IHhF3 _ H1 H5 as ih; clear IHhF3.
-    clear dependent v.
-    clear dependent E.
-    clear dependent u.
-    clear hlen H5 hF3.
-    rewrite Forall2_forall_nth_error in *.
-    destruct ih as [hlen ih].
-    split.
-    - repeat rewrite map_length in *.
+        (fst (shift_pairs shiftB (combine es ess))) vs.
+  Proof using A B shiftB R R_exp l shift_preserves_R shift_preserves_R_exp.
+    intros es ess vs vss hl hes hess.
+    unfold shift_pairs; unravel; let_destr_pair.
+    rewrite fst_prod_map_fst, fst_prod_map_snd.
+    rewrite vec_unzip_correct; cbn.
+    rewrite <- Vec.to_list_of_list_opp with (l:=vss).
+    rewrite <- Vec.to_list_of_list_opp with (l:=vs).
+    rewrite concat_vec_to_list.
+    assert (hlen : length vs = length (combine es ess)
+                   /\ length vss = length (combine es ess)).
+    { apply Forall3_length23 in hes.
+      apply sublist.Forall2_length in hess.
+      rewrite combine_length. lia. }
+    destruct hlen as [hlenvs hlenvss].
+    rewrite vec_to_list_fold_right with (v:=Vec.of_list vs).
+    rewrite <- vec_fold_right_eq_rect with (nm:=hlenvs) (v:=Vec.of_list vs).
+    rewrite <- vec_to_list_fold_right.
+    unfold vec_concat_list.
+    rewrite <- vec_fold_right_eq_rect with (nm:=hlenvss) (v:=Vec.of_list vss).
+    rewrite <- Vec.to_list_Forall2.
+    apply vec_shift_pairs_relate_fst.
+    - rewrite vec_map_of_list, vec_Forall3_eq_rect_l_to_mr.
+      do 2 rewrite rew_compose.
+      rewrite vec_Forall3_of_list.
+      rewrite map_fst_combine by assumption.
       assumption.
-    - intros n e v he hv.
-      rewrite nth_error_map in he.
-      destruct (nth_error (map fst (shift_pairs shift_exp (combine us ess))) n)
-        as [se |] eqn:hse;
-        cbn in *;
-        try discriminate.
-      inv he.
-      pose proof ih _ _ _ hse hv as h.
-      pose proof shift_exp_preserves_R [] t0 _ _ _ h as H;
-        cbn in H.
+    - rewrite vec_map_of_list, vec_Forall2_eq_rect_l,
+        rew_compose, vec_Forall2_of_list.
+      rewrite map_snd_combine by assumption.
       assumption.
+  Qed.
+
+  Polymorphic Universe c.
+  Polymorphic Context {C : Type@{c}}.
+  Polymorphic Variable shiftC : shifter C.
+  Polymorphic Variable Q : list A -> C -> A -> Prop.
+  Polymorphic Hypothesis shift_preserves_Q : forall as1 as2 as3 c a,
+      Q (as1 ++ as3) c a ->
+      Q (as1 ++ as2 ++ as3) (shiftC (length as1) (length as2) c) a.
+
+  Polymorphic Lemma shift_couple_relate_decl_list : forall b c esb esc asb asc,
+      relate_decl_list R_exp l esb asb ->
+      relate_decl_list R_exp l esc asc ->
+      relate_decl_list
+        R_exp l
+        (snd (shift_couple shiftB shiftC b c esb esc) ++ esb)
+        (asc ++ asb).
+  Proof using A B C R_exp l shiftB shiftC shift_preserves_R_exp.
+    intros b c esb esc asb asc hb hc.
+    unfold shift_couple.
+    do 2 rewrite prodn_shift_pairs_equation_2.
+    rewrite prodn_shift_pairs_equation_1. unravel. cbn.
+    rewrite add_0_r. auto.
+  Qed.
+
+  Polymorphic Lemma shift_couple_relate_couple : forall b c esb esc asb asc vb vc,
+      relate_decl_list R_exp l esb asb ->
+      relate_decl_list R_exp l esc asc ->
+      R (asb ++ l) b vb ->
+      Q (asc ++ l) c vc ->
+      R (asc ++ asb ++ l) (fst (fst (shift_couple shiftB shiftC b c esb esc))) vb
+      /\ Q (asc ++ asb ++ l) (snd (fst (shift_couple shiftB shiftC b c esb esc))) vc.
+  Proof using A B C Q R R_exp l shiftB shiftC shift_preserves_Q shift_preserves_R.
+    intros b c esb esc asb asc vb vc hesb hesc hb hc.
+    unfold shift_couple.
+    do 2 rewrite prodn_shift_pairs_equation_2.
+    rewrite prodn_shift_pairs_equation_1. unravel. cbn.
+    rewrite add_0_r.
+    rewrite ProdN.nth_equation_2, ProdN.hd_equation_1.
+    rewrite ProdN.map_uni2_equation_2 with (f:=shiftB).
+    rewrite ProdN.nth_equation_1.
+    apply relate_decl_list_length in hesb,hesc.
+    rewrite hesb,hesc.
+    split; auto.
+    apply shift_preserves_R with
+      (as1:=asb) (as2:=[]%list) (as3:=l) in hb.
+    apply shift_preserves_R with
+      (as1:=[]%list) (as2:=asc) (as3:=(asb ++ l)%list) in hb.
+    assumption.
   Qed.
 End RelateExprDeclList.

--- a/coq/lib/P4cub/Transformations/Lifting/TypingSpec.v
+++ b/coq/lib/P4cub/Transformations/Lifting/TypingSpec.v
@@ -11,55 +11,69 @@ Import RecordSetNotations.
 
 (** Typing specification for lifting in [Statementize.v] *)
 
+Notation type_decl_list := (relate_decl_list ∘ type_exp).
+
 Section TypeDeclList.
   Variable Δ : nat.
   Variable Γ : list Typ.t.
 
-  Definition type_decl_list : list Exp.t -> list Typ.t -> Prop :=
-    relate_decl_list (type_exp Δ) Γ.
-
   Local Hint Resolve relate_decl_list_length : core.
   
   Lemma type_decl_list_length : forall es ts,
-      type_decl_list es ts -> length es = length ts.
-  Proof using.
-    unfold type_decl_list; eauto.
-  Qed.
+      type_decl_list Δ Γ es ts -> length es = length ts.
+  Proof using. eauto. Qed.
   
   Local Hint Resolve shift_type_exp : core.
   Local Hint Resolve relate_decl_list_app : core.
     
   Lemma type_decl_list_app : forall τs1 τs2 es1 es2,
-      type_decl_list es1 τs1 ->
-      type_decl_list es2 τs2 ->
-      type_decl_list (shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1) (τs2 ++ τs1).
-  Proof using.
-    unfold type_decl_list. eauto.
-  Qed.
+      type_decl_list Δ Γ es1 τs1 ->
+      type_decl_list Δ Γ es2 τs2 ->
+      type_decl_list Δ Γ (shift_list shift_exp 0 (length es1) es2 ++ es1) (τs2 ++ τs1).
+  Proof using. eauto. Qed.
 
   Local Hint Resolve shift_pairs_relate_snd : core.
     
   Lemma shift_pairs_type_snd : forall ess tss,
-      Forall2 type_decl_list (map snd ess) tss ->
+      Forall2 (type_decl_list Δ Γ) (map snd ess) tss ->
       type_decl_list
-        (concat (map snd (shift_pairs shift_exp ess)))
+        Δ Γ
+        (concat (snd (shift_pairs shift_exp ess)))
         (concat tss).
-  Proof using.
-    unfold type_decl_list. eauto.
-  Qed.
+  Proof using. eauto. Qed.
   
   Local Hint Resolve shift_pairs_relate_fst : core.
   
-  Lemma shift_pairs_relate_fst : forall es ess ts tss,
+  Lemma shift_pairs_type_fst : forall es ess ts tss,
       length es = length ess ->
       Forall3 (fun ts e t => `⟨ Δ, ts ++ Γ ⟩ ⊢ e ∈ t) tss es ts ->
-      Forall2 type_decl_list ess tss ->
+      Forall2 (type_decl_list Δ Γ) ess tss ->
       Forall2
         (type_exp Δ (concat tss ++ Γ))
-        (map fst (shift_pairs shift_exp (combine es ess))) ts.
-  Proof using.
-    unfold type_decl_list. eauto.
-  Qed.
+        (fst (shift_pairs shift_exp (combine es ess))) ts.
+  Proof using. eapply shift_pairs_relate_fst; eauto. Qed.
+
+  Local Hint Resolve shift_couple_relate_decl_list : core.
+
+  Lemma shift_couple_exp_type_decl_list : forall e1 e2 es1 es2 ts1 ts2,
+      type_decl_list Δ Γ es1 ts1 ->
+      type_decl_list Δ Γ es2 ts2 ->
+      type_decl_list
+        Δ Γ
+        (snd (shift_couple shift_exp shift_exp e1 e2 es1 es2) ++ es1)
+        (ts2 ++ ts1).
+  Proof using. eauto. Qed.
+
+  Local Hint Resolve shift_couple_relate_couple : core.
+
+  Lemma shift_couple_exp_type_couple : forall e1 e2 es1 es2 t1 t2 ts1 ts2,
+      type_decl_list Δ Γ es1 ts1 ->
+      type_decl_list Δ Γ es2 ts2 ->
+      `⟨ Δ, ts1 ++ Γ ⟩ ⊢ e1 ∈ t1 ->
+      `⟨ Δ, ts2 ++ Γ ⟩ ⊢ e2 ∈ t2 ->
+      `⟨ Δ, ts2 ++ ts1 ++ Γ ⟩ ⊢ fst (fst (shift_couple shift_exp shift_exp e1 e2 es1 es2)) ∈ t1 
+      /\ `⟨ Δ, ts2 ++ ts1 ++ Γ ⟩ ⊢ snd (fst (shift_couple shift_exp shift_exp e1 e2 es1 es2)) ∈ t2.
+  Proof using. eauto. Qed.
 End TypeDeclList.
 
 Section TypeExp.
@@ -79,10 +93,30 @@ Section TypeExp.
   Local Hint Constructors typ_ok_lists : core.
   Local Hint Constructors Forall3 : core.
   Local Hint Resolve type_exp_typ_ok : core.
+  Local Hint Resolve shift_couple_exp_type_couple : core.
+  Local Hint Resolve shift_couple_exp_type_decl_list : core.
+  Local Hint Resolve shift_couple_relate_decl_list : core.
+  Local Hint Resolve shift_pairs_relate_fst : core.
+  Local Hint Resolve shift_pairs_relate_snd : core.
+  Local Hint Resolve shift_pairs_type_fst : core.
+  Local Hint Resolve shift_pairs_type_snd : core.
+  Local Hint Resolve Forall3_length23 : core.
 
   Ltac esolve_lift := eexists; esplit; eauto; assumption.
 
   Local Hint Extern 5 => esolve_lift : core.
+
+  Ltac shift_couple_type_exp_resolve :=
+    lazymatch goal with
+      hes1: type_decl_list _ _ ?es1 ?ts1,
+      hes2: type_decl_list _ _ ?es2 ?ts2,
+      he1: `⟨ _, ?ts1 ++ _ ⟩ ⊢ ?e1 ∈ ?t1,
+      he2: `⟨ _, ?ts2 ++ _ ⟩ ⊢ ?e2 ∈ ?t2
+      |- _ => pose proof shift_couple_exp_type_couple
+              _ _ _ _ _ _ _ _ _ _ hes1 hes2 he1 he2 as [? ?]
+    end.
+
+  Local Hint Extern 3 => shift_couple_type_exp_resolve : core.
 
   Hypothesis hG : Forall (typ_ok Δ) Γ.
   
@@ -92,7 +126,6 @@ Section TypeExp.
             type_decl_list Δ Γ es τs
             /\ `⟨ Δ, τs ++ Γ ⟩ ⊢ e' ∈ τ.
   Proof using hG Γ Δ.
-    unfold type_decl_list.
     intros e t het;
       induction het using custom_type_exp_ind;
       intros E Es h; inv h; eauto.
@@ -106,28 +139,13 @@ Section TypeExp.
       exists (τ :: ts2 ++ ts1).
       split; eauto.
       constructor; eauto.
-      rewrite <- app_assoc.
-      erewrite relate_decl_list_length
-        with (lb := es1) (la := ts1) by eassumption.
-      erewrite relate_decl_list_length
-        with (lb := es2) (la := ts2) by eassumption.
-      econstructor; eauto.
-      eapply shift_type_exp with
-        (ts1 := []) (ts2 := ts2); cbn; eauto.
+      rewrite <- app_assoc. eauto.
     - pose proof IHhet1 hG _ _ H5
         as (ts1 & hts1 & ht1); clear IHhet1; eauto.
       pose proof IHhet2 hG _ _ H6
         as (ts2 & hts2 & ht2); clear IHhet2; eauto.
       exists (ts2 ++ ts1).
-      split; eauto.
-      rewrite <- app_assoc.
-      erewrite relate_decl_list_length
-        with (lb := es1) (la := ts1) by eassumption.
-      erewrite relate_decl_list_length
-        with (lb := es2) (la := ts2) by eassumption.
-      econstructor; eauto.
-      eapply shift_type_exp with
-        (ts1 := []) (ts2 := ts2); cbn; eauto.
+      rewrite <- app_assoc. eauto.
     - pose proof IHhet hG _ _ H6 as (ts & hts & ht); eauto.
     - pose proof Forall2_dumb _ _ _ _ _ _ hG H2 as H'; clear H2.
       pose proof Forall2_specialize_Forall3
@@ -152,14 +170,11 @@ Section TypeExp.
       pose proof typ_of_lists_correct _ _ _ _ _ _ H0 H1; subst.
       exists (typ_of_lists ls es :: concat tss).
       split; eauto.
-      constructor.
-      + econstructor; eauto.
-        apply shift_pairs_relate_fst;
-          eauto using Forall3_length23.
-      + apply shift_pairs_relate_snd; eauto.
-        rewrite sublist.combine_snd
-          by eauto using Forall3_length23.
-        assumption.
+      constructor; eauto.
+      eapply shift_pairs_type_snd.
+      rewrite sublist.combine_snd
+        by eauto using Forall3_length23.
+      assumption.
   Qed.
 
   Local Hint Resolve Lift_exp_type_exp : core.
@@ -171,7 +186,6 @@ Section TypeExp.
           type_decl_list Δ Γ es ts
           /\ type_trns total_states Δ (ts ++ Γ) pe'.
     Proof using hG Γ Δ.
-      unfold type_decl_list.
       intros n pe hpe pe' es ht.
       inv hpe; inv ht; eauto.
       pose proof Lift_exp_type_exp _ _ H0 _ _ H7 as (ts & hts & ht).
@@ -180,7 +194,27 @@ Section TypeExp.
 
     Local Hint Constructors lexpr_ok : core.
     Local Hint Resolve shift_lexpr_ok : core.
+    Local Hint Resolve shift_exp_0 : core.
 
+    Lemma shift_couple_lexpr_ok_1 : forall e1 e2 es1 es2,
+        lexpr_ok e1 ->
+        lexpr_ok (fst (fst (shift_couple shift_exp shift_exp e1 e2 es1 es2))).
+    Proof using.
+      intros e1 e2 es1 es2 h.
+      rewrite shift_couple_spec by eauto; cbn; auto.
+    Qed.
+
+    Lemma shift_couple_lexpr_ok_2 : forall e1 e2 es1 es2,
+        lexpr_ok e2 ->
+        lexpr_ok (snd (fst (shift_couple shift_exp shift_exp e1 e2 es1 es2))).
+    Proof using.
+      intros e1 e2 es1 es2 h.
+      rewrite shift_couple_spec by eauto; cbn; auto.
+    Qed.
+
+    Local Hint Resolve shift_couple_lexpr_ok_1 : core.
+    Local Hint Resolve shift_couple_lexpr_ok_2 : core.
+    
     Lemma Lift_exp_lexpr_ok : forall e,
         lexpr_ok e -> forall e' es,
           Lift_exp e e' es -> lexpr_ok e'.
@@ -215,6 +249,7 @@ Section TypeStm.
   Variable Δ : nat.
   
   Local Hint Constructors type_stm : core.
+  Local Hint Constructors SumForall : core.
 
   (** Specification of [unwind_vars]. *)
   Lemma type_decl_list_Unwind : forall Γ es ts,
@@ -225,7 +260,7 @@ Section TypeStm.
   Proof using.
     intros G es ts H; induction H;
       intros fs c s sig h; unravel in *; eauto.
-  Admitted.
+  Qed.
 
   Local Hint Resolve type_decl_list_Unwind : core.
   Local Hint Resolve type_decl_list_length : core.

--- a/coq/lib/Utils/ForallMap.v
+++ b/coq/lib/Utils/ForallMap.v
@@ -1117,3 +1117,41 @@ Section Forall4.
     Forall4 ts us vs ws ->
     Forall4 (t :: ts) (u :: us) (v :: vs) (w :: ws).
 End Forall4.
+
+Lemma Forall3_Forall2_12 : forall (U V : Type) (R : U -> U -> V -> Prop) us vs,
+    Forall3 R us us vs <-> Forall2 (fun u => R u u) us vs.
+Proof.
+  intros U V R us vs.
+  rewrite Forall3_forall, Forall2_forall_nth_error.
+  split.
+  - intros (_ & hlen & h).
+    split; eauto.
+  - intros [hlen h].
+    repeat split; eauto.
+    intros n u1 u2 v hu1 hu2 hv.
+    rewrite hu1 in hu2; inv hu2. eauto.
+Qed.
+
+Lemma Forall3_Forall2_13 : forall (U V : Type) (R : U -> V -> U -> Prop) us vs,
+    Forall3 R us vs us <-> Forall2 (fun u v => R u v u) us vs.
+Proof.
+  intros U V R us vs.
+  rewrite Forall3_permute_23, Forall3_Forall2_12.
+  reflexivity.
+Qed.
+
+Lemma Forall3_Forall2_23 : forall (U V : Type) (R : U -> V -> V -> Prop) us vs,
+    Forall3 R us vs vs <-> Forall2 (fun u v => R u v v) us vs.
+Proof.
+  intros U V R us vs.
+  rewrite Forall3_permute_12, Forall3_Forall2_13,
+    Forall2_flip. reflexivity.
+Qed.
+
+Lemma Forall3_Forall_123 : forall (U : Type) (R : U -> U -> U -> Prop) us,
+    Forall3 R us us us <-> Forall (fun u => R u u u) us.
+Proof using.
+  intros U R us.
+  rewrite Forall3_Forall2_12, Forall2_Forall.
+  reflexivity.
+Qed.

--- a/coq/lib/Utils/ProdN.v
+++ b/coq/lib/Utils/ProdN.v
@@ -1,0 +1,315 @@
+From Equations Require Import Equations.
+Require Import Poulet4.Utils.VecUtil Poulet4.Utils.Util.FunUtil.
+Import Vec.VectorNotations.
+
+Section VecMap.
+  Polymorphic Universes a b.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}}.
+  Polymorphic Variable f : A -> B.
+
+  Import Vec.VectorNotations.
+  Local Open Scope vector_scope.
+
+  Polymorphic Equations vec_map : forall {n}, Vec.t A n -> Vec.t B n := {
+      vec_map [] := [];
+      vec_map (a :: v) := f a :: vec_map v
+    }.
+End VecMap.
+
+Section ProdN.
+  Polymorphic Universe a.
+  
+  Polymorphic Inductive t : forall {n : nat}, Vec.t Type@{a} n -> Type@{a+1} :=
+  | nil : t []%vector
+  | cons : forall {A : Type@{a}} {n : nat} {v : Vec.t Type@{a} n},
+      A -> t v -> t (A :: v)%vector.
+
+  Polymorphic Derive Signature NoConfusion NoConfusionHom Subterm for t.
+End ProdN.
+
+Module ProdNNotations.
+  Declare Scope prodn_scope.
+  Delimit Scope prodn_scope with prodn.
+  Notation "[ ]" := nil (format "[ ]") : prodn_scope.
+  Notation "h :: t" := (cons h t) (at level 60, right associativity)
+      : prodn_scope.
+  Notation "[ x ]" := (x :: []) : prodn_scope.
+  Notation "[ x ; y ; .. ; z ]"
+    := (cons _ x _ (cons _ y _ .. (cons _ z _ (nil _)) ..)) : prodn_scope.
+  (*Notation "v [@ p ]" := (nth v p) (at level 1, format "v [@ p ]") : prodn_scope.
+  Infix "++" := append : prodn_scope.*)
+End ProdNNotations.
+
+
+Section ProdN.
+  Import ProdNNotations.
+  Open Scope prodn_scope.
+
+  Polymorphic Universe a.
+  
+  Polymorphic Equations append : forall {m n : nat} {v1 : Vec.t Type@{a} m} {v2 : Vec.t Type@{a} n},
+      t v1 -> t v2 -> t (v1 ++ v2)%vector := {
+      append [] p2 := p2;
+      append (a :: p1) p2 := a :: append p1 p2
+    }.
+
+  Polymorphic Equations nth : forall {n : nat} {v : Vec.t Type@{a} n} (i : Fin.t n),
+      t v -> (v [@ i])%vector := {
+      nth Fin.F1 (a :: _) := a;
+      nth (Fin.FS i) (_ :: p) := nth i p
+    }.
+
+  Polymorphic Inductive each :
+    forall {n : nat} {v : Vec.t Type@{a} n},
+      t (Vec.map (fun A => A -> Prop) v) -> t v -> Prop :=
+  | each_nil : each (v:=[]%vector) [] []
+  | each_cons
+      {A : Type@{a}} {n : nat} {v : Vec.t Type@{a} n} (a : A) (p : t v)
+      (P : A -> Prop) (props : t (Vec.map (fun A => A -> Prop) v)) :
+    P a -> each props p -> each (v:=A :: v)%vector (P :: props) (a :: p).
+
+  Polymorphic Derive Signature for each.
+
+  Section eachuni.
+    Polymorphic Universe b.
+    Polymorphic Context {B : Type@{b}}.
+    Polymorphic Variable b : B.
+
+    Polymorphic Inductive each_uni1 : forall {n : nat} {v : Vec.t Type@{a} n},
+        t (Vec.map (fun A => B -> A -> Prop) v) -> t v -> Prop :=
+    | each_uni1_nil : each_uni1 (v:=[]%vector) [] []
+    | each_uni1_cons
+        {A : Type@{a}} {n : nat} {v : Vec.t Type@{a} n} (a : A) (p : t v)
+        (R : B -> A -> Prop) (rels : t (Vec.map (fun A => B -> A -> Prop) v)) :
+      R b a -> each_uni1 rels p -> each_uni1 (v:=A :: v)%vector (R :: rels) (a :: p).
+
+    Polymorphic Derive Signature for each_uni1.
+    
+    Polymorphic Universe c.
+    Polymorphic Context {C : Type@{c}}.
+
+    Polymorphic Inductive relate_uni1 : forall {n} {v : Vec.t Type@{a} n},
+        t (Vec.map (fun A => B -> A -> C -> Prop) v) -> t v -> Vec.t C n -> Prop :=
+    | relate_uni1_nil : relate_uni1 (v:=[]%vector) [] [] []%vector
+    | relate_uni1_cons {A : Type@{a}} {n : nat} {v : Vec.t Type@{a} n} (a : A) (p : t v)
+        (R : B -> A -> C -> Prop) (rels : t (Vec.map (fun A => B -> A -> C -> Prop) v))
+        (c : C) (cs : Vec.t C n) :
+      R b a c ->
+      relate_uni1 rels p cs ->
+      relate_uni1 (v:=A :: v)%vector (R :: rels) (a :: p) (c :: cs)%vector.
+
+    Polymorphic Derive Signature for relate_uni1.
+  End eachuni.
+  
+  Section fixed.
+    Polymorphic Context {A : Type@{a}}.
+
+    Polymorphic Equations hd : forall {n : nat} {v : Vec.t Type@{a} n},
+        t (A :: v)%vector -> A := {
+        hd (a :: _) := a
+      }.
+
+    Polymorphic Equations tl : forall {n : nat} {v : Vec.t Type@{a} n},
+        t (A :: v)%vector -> t v := {
+        tl (_ :: p) := p
+      }.
+
+    Polymorphic Equations to_vec : forall {n : nat}, t (vec_rep n A) -> Vec.t A n := {
+      to_vec (n:=O) [] := []%vector;
+        to_vec (a :: p) := (a :: to_vec p)%vector;
+      }.
+    
+    Polymorphic Equations of_vec : forall {n : nat}, Vec.t A n -> t (vec_rep n A) := {
+        of_vec []%vector := [];
+        of_vec (a :: v)%vector := a :: of_vec v
+      }.
+
+    Polymorphic Definition to_list {n : nat} : t (vec_rep n A) -> list A :=
+      Vec.to_list ∘ to_vec.
+
+    Polymorphic Definition of_list (l : list A) : t (vec_rep (length l) A) :=
+      of_vec $ Vec.of_list l.
+
+    Polymorphic Fixpoint rep (a : A) (n : nat) : t (vec_rep n A) :=
+      match n with
+      | O => []
+      | S n => a :: rep a n
+      end.
+
+    Section RepParam.
+      Polymorphic Universe b.
+      Polymorphic Context {B : A -> Type@{b}} {a : A}.
+      Polymorphic Variable (ba : B a).
+      
+      Polymorphic Fixpoint rep_param (n : nat) : ProdN.t (Vec.map B (vec_rep n a)) :=
+        match n with
+        | O => []
+        | S n => ba :: rep_param n
+        end.
+    End RepParam.
+  End fixed.
+  
+  Section MapUni.
+    Polymorphic Context {A : Type@{a}}.
+    Polymorphic Variable a : A.
+    
+    Polymorphic Universe b.
+
+    Polymorphic Equations map_uni1 :
+      forall {n : nat} {BS : Vec.t Type@{b} n},
+        ProdN.t (Vec.map (fun B => A -> B -> B) BS) ->
+        ProdN.t BS -> ProdN.t BS := {
+          map_uni1 [] [] := [];
+          map_uni1 (f :: fs) (b :: p) := f a b :: map_uni1 fs p
+      }.
+
+    Polymorphic Context {B : Type@{b}}.
+    Polymorphic Variable b : B.
+
+    Polymorphic Universe c.
+
+    Polymorphic Equations map_uni2 :
+      forall {n : nat} {CS : Vec.t Type@{c} n},
+        ProdN.t (Vec.map (fun C => A -> B -> C -> C) CS) ->
+        ProdN.t CS -> ProdN.t CS := {
+        map_uni2 [] [] := [];
+        map_uni2 (f :: fs) (c :: p) := f a b c :: map_uni2 fs p
+      }.
+  End MapUni.
+  
+  Section Map.
+    Polymorphic Universe b.
+    
+    Polymorphic Equations map : forall {n : nat} {dom : Vec.t Type@{a} n} {ran : Vec.t Type@{b} n},
+        t (Vec.map2 (fun (A : Type@{a}) (B : Type@{b}) => A -> B) dom ran) ->
+        t dom -> t ran := {
+        map (dom:=[]%vector) (ran:=[]%vector) [] [] := [];
+        map (f :: fp) (a :: p) := f a :: map fp p
+      }.
+    
+    (* Takes too long to build:
+    Polymorphic Universe c.
+
+    Set Equations Transparent.
+    
+    Polymorphic Equations map2 :
+      forall {n : nat} {dom1 : Vec.t Type@{a} n} {dom2 : Vec.t Type@{b} n} {ran : Vec.t Type@{c} n},
+      t (vec_map3 (fun (A : Type@{a}) (B : Type@{b}) (C : Type@{c}) => A -> B -> C) dom1 dom2 ran) ->
+      t dom1 -> t dom2 -> t ran := {
+        map2 (ran := []%vector) [] [] [] := [];
+        map2 (ran := (_ :: _)%vector) (f :: fp) (a :: p1) (b :: p2) := f a b :: map2 fp p1 p2
+      }.*)
+
+    (*Section Map2.
+      Polymorphic Universe c.
+
+      Polymorphic Context {n : nat} {dom1 : Vec.t Type@{a} n} {dom2 : Vec.t Type@{b} n} {ran : Vec.t Type@{c} n}.
+      Polymorphic Variables
+                    (fs : t (vec_map3 (fun (A : Type@{a}) (B : Type@{b}) (C : Type@{c}) => A -> B -> C) dom1 dom2 ran))
+                    (pa : t dom1) (pb : t dom2).
+
+      Definition map2 : t ran :=
+      
+    End Map2.*)
+  End Map.
+End ProdN.
+
+Section MapUni2Thm.
+  Import Vec.VectorNotations.
+  Import ProdNNotations.
+  Open Scope prodn_scope.
+  
+  Polymorphic Universes a b c.
+  Polymorphic Context {A : Type@{a}} {B : Type@{a}} {C : Type@{a}}.
+  Polymorphic Variables (f : A -> B -> C -> C) (a : A) (b : B).
+  
+  Polymorphic Lemma to_vec_map_uni2 :
+    forall {n} (p : ProdN.t (vec_rep n C)),
+      to_vec
+        (map_uni2 (CS:=vec_rep n C) a b
+           (ProdN.rep_param f n) p)
+      = Vec.map (f a b) (ProdN.to_vec p).
+  Proof using.
+    intros n p.
+    funelim (to_vec p); cbn.
+    - rewrite map_uni2_equation_1, to_vec_equation_1; reflexivity.
+    - rewrite map_uni2_equation_2. do 2 rewrite to_vec_equation_2.
+      cbn; f_equal; auto.
+  Qed.
+End MapUni2Thm.
+
+Section eachForall.
+  Import ProdNNotations.
+  Open Scope prodn_scope.
+  
+  Polymorphic Universe a.
+  Polymorphic Context {A : Type@{a}}.
+  Polymorphic Variable P : A -> Prop.
+  
+  Local Hint Constructors each : core.
+  
+  Polymorphic Lemma Forall_each :
+    forall {n : nat} (v : Vec.t A n),
+      Vec.Forall P v ->
+      each (rep_param P n) (of_vec v).
+  Proof using.
+    intros n v hv; depind hv; cbn; auto.
+    rewrite of_vec_equation_2.
+    auto.
+  Qed.
+
+  Local Hint Constructors Vec.Forall : core.
+  
+  Polymorphic Lemma each_Forall :
+    forall {n : nat} (p : ProdN.t (vec_rep n A)),
+      ProdN.each (ProdN.rep_param P n) p ->
+      Vec.Forall P (to_vec p).
+  Proof using.
+    intro n; induction n as [| n ih];
+      intros p hp; cbn in *; depelim hp.
+    - rewrite to_vec_equation_1. constructor.
+    - rewrite to_vec_equation_2. auto.
+  Qed.
+End eachForall.
+
+Module ProdNZip.
+  Section prod.
+    Polymorphic Universes a b.
+    Variables (A : Type@{a}) (B : Type@{b}).
+    Polymorphic Variant prod : Type@{max(a,b)} := pair : A -> B -> prod.
+    
+    Polymorphic Definition fst '(pair a _ : prod) : A := a.
+    Polymorphic Definition snd '(pair _ b : prod) : B := b.
+  End prod.
+  
+  Arguments pair {A} {B}.
+  Arguments fst {A} {B}.
+  Arguments snd {A} {B}.
+
+  Set Warnings "-notation-overridden".
+  Notation "x * y" := (prod x y) : type_scope.
+  Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
+  
+  Section Zip.
+    Import ProdNNotations.
+    Open Scope prodn_scope.
+    
+    Polymorphic Universe a b.
+
+    Polymorphic Equations zip :
+      forall {n : nat} {v1 : Vec.t Type@{a} n} {v2 : Vec.t Type@{b} n},
+        t v1 -> t v2 -> t (Vec.map2 prod v1 v2) := {
+        zip [] [] := [];
+        zip (a :: p1) (b :: p2) := (a, b) :: zip p1 p2
+      }.
+
+    Polymorphic Equations unzip :
+      forall {n : nat} {v1 : Vec.t Type@{a} n} {v2 : Vec.t Type@{b} n},
+        t (Vec.map2 prod v1 v2) -> t v1 * t v2 := {
+        unzip (v1:=[]%vector) (v2:=[]%vector) [] := ([], []);
+        unzip (v1:=(_ :: _)%vector) (v2:=(_ :: _)%vector)
+          ((a, b) :: p) :=
+          let '(p1, p2) := unzip p in (a :: p1, b :: p2)
+      }.
+  End Zip.
+End ProdNZip.

--- a/coq/lib/Utils/Util/EquivUtil.v
+++ b/coq/lib/Utils/Util/EquivUtil.v
@@ -228,8 +228,27 @@ End Forall2_Equivalence.
 
 (** Option Predicate *)
 Variant predop {A : Type} (P : A -> Prop) : option A -> Prop :=
-| predop_none : predop P None
-| predop_some (a : A) : P a -> predop P (Some a).
+  | predop_none : predop P None
+  | predop_some (a : A) : P a -> predop P (Some a).
+
+Section Predop.
+  Context {A B : Type}.
+  Variable P : A -> Prop.
+
+  Local Hint Constructors predop : core.
+
+  Lemma predop_pat_fst : forall (o : option (A * B)),
+      predop (fun '(a, _) => P a) o <-> predop (fun ab => P (fst ab)) o.
+  Proof using.
+    intros [[a b] |]; split; intro h; inv h; auto.
+  Qed.
+  
+  Lemma predop_pat_snd : forall (o : option (B * A)),
+      predop (fun '(_, a) => P a) o <-> predop (fun ba => P (snd ba)) o.
+  Proof using.
+    intros [[a b] |]; split; intro h; inv h; auto.
+  Qed.
+End Predop.
 
 (** * Option Relations *)
 Section Relop.

--- a/coq/lib/Utils/Util/FunUtil.v
+++ b/coq/lib/Utils/Util/FunUtil.v
@@ -52,15 +52,57 @@ Tactic Notation "match_some_inv" "as" simple_intropattern(E) :=
 
 Tactic Notation "match_some_inv" := match_some_inv as ?.
 
-(** * Utility Functions *)
+Ltac pair_destr :=
+  lazymatch goal with
+  | h: (_,_) = (_,_) |- _ => inv h
+  end.
+
+Ltac conj_destr :=
+  lazymatch goal with
+    h: _ /\ _ |- _ => destruct h as [? ?]
+  end.
+
+Ltac let_destr_pair :=
+  lazymatch goal with
+  | h: context [let (_,_) := ?a in _] |- _
+    => rewrite surjective_pairing with (p:=a) in h; cbn
+  | |- context [let (_,_) := ?a in _]
+    => rewrite surjective_pairing with (p:=a); cbn
+  end.
+
+Ltac pair_fst_snd_eqns :=
+  lazymatch goal with
+    h: _ = (_,_) |- _
+    => pose proof f_equal fst h as ?; pose proof f_equal snd h as ?; clear h;
+      cbn in *; subst; cbn in *
+  end.
+
+(** * Utility Definitions *)
 
 Section MapProd.
-  Context {A B C : Type}.
-  Variable f : A -> B.
+  Polymorphic Universes a b c.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}} {C : Type@{c}}.
+  Polymorphic Variable f : A -> B.
 
-  Definition map_fst '((a,c) : A * C) : B * C := (f a, c).
+  Polymorphic Definition prod_map_fst '((a,c) : A * C) : B * C := (f a, c).
 
-  Definition map_snd '((c,a) : C * A) : C * B := (c, f a).
+  Polymorphic Definition prod_map_snd '((c,a) : C * A) : C * B := (c, f a).
+
+  Polymorphic Lemma fst_prod_map_fst : forall ac,
+      fst (prod_map_fst ac) = f (fst ac).
+  Proof using. intros [? ?]; reflexivity. Qed.
+
+  Polymorphic Lemma snd_prod_map_fst : forall ac,
+      snd (prod_map_fst ac) = snd ac.
+  Proof using. intros [? ?]; reflexivity. Qed.
+  
+  Polymorphic Lemma snd_prod_map_snd : forall ca,
+      snd (prod_map_snd ca) = f (snd ca).
+  Proof using. intros [? ?]; reflexivity. Qed.
+
+  Polymorphic Lemma fst_prod_map_snd : forall ca,
+      fst (prod_map_snd ca) = fst ca.
+  Proof using. intros [? ?]; reflexivity. Qed.
 End MapProd.
 
 Fixpoint n_compose {A : Type} (n : nat) (f : A -> A) (x : A) : A :=

--- a/coq/lib/Utils/Util/ListUtil.v
+++ b/coq/lib/Utils/Util/ListUtil.v
@@ -458,3 +458,24 @@ Proof.
   apply f_equal with (f:=List.length (A:=A)) in h.
   rewrite !app_length in h. lia.
 Qed.
+
+Section SplitMap.
+  Polymorphic Universes a b.
+  Context {A : Type@{a}} {B : Type@{b}}.
+
+  Polymorphic Lemma fst_split_map_fst : forall (l : list (A * B)),
+      fst (split l) = List.map fst l.
+  Proof using.
+    intro l; induction l as [| [a b] l ih]; cbn; trivial.
+    destruct (split l) as [la lb]; cbn in *.
+    rewrite ih; reflexivity.
+  Qed.
+  
+  Polymorphic Lemma snd_split_map_snd : forall (l : list (A * B)),
+      snd (split l) = List.map snd l.
+  Proof using.
+    intro l; induction l as [| [a b] l ih]; cbn; trivial.
+    destruct (split l) as [la lb]; cbn in *.
+    rewrite ih; reflexivity.
+  Qed.
+End SplitMap.

--- a/coq/lib/Utils/VecUtil.v
+++ b/coq/lib/Utils/VecUtil.v
@@ -1,0 +1,646 @@
+Require Coq.Vectors.Vector.
+Module Vec := Coq.Vectors.Vector.
+From Equations Require Import Equations.
+Require Import Poulet4.Utils.Util.FunUtil Poulet4.Utils.ForallMap.
+
+Derive NoConfusion NoConfusionHom Subterm for nat.
+Derive NoConfusion NoConfusionHom Subterm for list.
+
+Module FinEquations.
+  Derive Signature NoConfusion NoConfusionHom Subterm for Fin.t.
+End FinEquations.
+
+Module VecEquations.
+  Derive Signature NoConfusion NoConfusionHom Subterm for Vec.t.
+
+  Derive Signature for Vec.Forall.
+
+  Derive Signature for Vec.Forall2.
+End VecEquations.
+
+Definition vec_sum {n : nat} (v : Vec.t nat n) : nat :=
+  Vec.fold_right Nat.add v 0.
+
+Lemma vec_sum_eq_rect : forall {m n : nat} (hmn : m = n) (v : Vec.t nat m),
+    vec_sum (eq_rect _ _ v _ hmn) = vec_sum v.
+Proof using.
+  intros m n hmn v. depelim hmn. reflexivity.
+Qed.
+
+Section Lemmas.
+  Import List.ListNotations.
+  Import Vec.VectorNotations.
+  Local Open Scope vector_scope.
+  
+  Polymorphic Universe a.
+  Polymorphic Context {A : Type@{a}}.
+
+  Polymorphic Inductive vec_In (a : A) : forall {n}, Vec.t A n -> Prop :=
+  | vec_In_hd {n} (v : Vec.t A n) :
+    vec_In a (a :: v)
+  | vec_In_tl {n} (h : A) (v : Vec.t A n) :
+    vec_In a v -> vec_In a (h :: v).
+
+  Polymorphic Derive Signature for vec_In.
+  
+  Polymorphic Lemma vec_In_nth : forall a {n} (v : Vec.t A n),
+      vec_In a v -> exists m, v [@ m ] = a.
+  Proof using.
+    intros a n v h. depind h.
+    - exists Fin.F1. reflexivity.
+    - destruct IHh as [m ih].
+      exists (Fin.FS m). cbn. assumption.
+  Qed.
+
+  Local Hint Constructors vec_In : core.
+  
+  Polymorphic Lemma nth_vec_In : forall {n} (m : Fin.t n) (v : Vec.t A n),
+      vec_In (v [@ m ]) v.
+  Proof using.
+    intros n m v.
+    depind m; depelim v; cbn; auto.
+  Qed.
+  
+  Section ForallForall.
+    Polymorphic Variable P : A -> Prop.
+
+    Local Hint Constructors Vec.Forall : core.
+    Local Hint Constructors List.Forall : core.
+    
+    Polymorphic Lemma vec_Forall_of_list : forall (l : list A),
+        Vec.Forall P (Vec.of_list l) <-> List.Forall P l.
+    Proof using.
+      intro l; split; intro h.
+      - induction l; cbn in *; depelim h; auto.
+      - induction h; cbn; auto.
+    Qed.
+
+    Polymorphic Lemma vec_Forall_forall
+      : forall {n} (v : Vec.t A n),
+        Vec.Forall P v <-> forall a, vec_In a v -> P a.
+    Proof using.
+      intros n v; split; intro h.
+      - intros a ha. depind h; depelim ha; auto.
+      - depind v; auto.
+    Qed.
+  End ForallForall.
+  
+  Polymorphic Fixpoint vec_rep (n : nat) (a : A) : Vec.t A n :=
+    match n with
+    | O => []
+    | S n => a :: vec_rep n a
+    end.
+
+  Polymorphic Definition vec_concat_list {n : nat} (v : Vec.t (list A) n) : list A :=
+    Vec.fold_right (List.app (A:=A)) v []%list.
+
+  Polymorphic Lemma vec_concat_list_nil :
+    vec_concat_list [] = []%list.
+  Proof using. reflexivity. Qed.
+
+  Polymorphic Lemma vec_concat_list_cons : forall {n : nat} l (v : Vec.t (list A) n),
+      vec_concat_list (l :: v) = (l ++ vec_concat_list v)%list.
+  Proof using. reflexivity. Qed.
+
+  Polymorphic Lemma length_vec_concat_list : forall {n : nat} (v : Vec.t (list A) n),
+      List.length (vec_concat_list v)
+      = Vec.fold_right Nat.add (Vec.map (length (A:=A)) v) 0.
+  Proof using.
+    intros n v; depind v;
+      try rewrite vec_concat_list_nil;
+      try rewrite vec_concat_list_cons; cbn; trivial.
+    rewrite List.app_length.
+    f_equal; assumption.
+  Qed.
+
+  Polymorphic Lemma list_concat_fold_right : forall (l : list (list A)),
+      List.concat l = List.fold_right (List.app (A:=A)) []%list l.
+  Proof using.
+    intro l; induction l as [| h t ih]; cbn; f_equal; auto.
+  Qed.
+
+  Polymorphic Lemma concat_vec_to_list : forall {n} (v : Vec.t (list A) n),
+      List.concat (Vec.to_list v) = vec_concat_list v.
+  Proof using.
+    intros a v.
+    rewrite list_concat_fold_right,
+      <- Vec.to_list_fold_right.
+    reflexivity.
+  Qed.
+
+  Polymorphic Lemma vec_to_list_fold_right : forall {n} (v : Vec.t A n),
+      Vec.to_list v = Vec.fold_right List.cons v []%list.
+  Proof using.
+    intros n v. reflexivity.
+  Qed.
+  
+  Polymorphic Universes b.
+  Polymorphic Context {B : Type@{b}}.
+
+  Section Forall2.
+    Polymorphic Variable R : A -> B -> Prop.
+    Local Hint Constructors Vec.Forall2 : core.
+  
+    Polymorphic Lemma vec_Forall2_forall :
+      forall {n} (va : Vec.t A n) (vb : Vec.t B n),
+        Vec.Forall2 R va vb <-> forall m, R (va [@ m]) (vb [@ m]).
+    Proof using.
+      intros n va vb; split; intro h.
+      - intro m. depind h.
+        + depelim m.
+        + depelim m0; cbn; auto.
+      - generalize dependent vb.
+        depind va; intros vb H; depelim vb; auto.
+        pose proof H Fin.F1 as H1; cbn in H1.
+        constructor; auto. apply IHva.
+        intro m. specialize H with (Fin.FS m).
+        cbn in H. assumption.
+    Qed.
+
+    Local Hint Constructors List.Forall2 : core.
+
+    Local Hint Resolve PeanoNat.Nat.eq_dec : core.
+    Local Hint Resolve Peano_dec.UIP_nat : core.
+    
+    Polymorphic Lemma vec_Forall2_of_list : forall la lb (hlen : length lb = length la),
+        Vec.Forall2 R (Vec.of_list la) (eq_rect _ _ (Vec.of_list lb) _ hlen)
+        <-> List.Forall2 R la lb.
+    Proof using.
+      intro la; induction la as [| a la ih];
+        intros [| b lb] hlen; cbn in *;
+        try discriminate; split; intro h; auto.
+      - rewrite <- Eqdep_dec.eq_rect_eq_dec by auto; auto.
+      - assert (hlen' : length lb = length la) by lia.
+        replace hlen with (f_equal S hlen') in h by auto.
+        rewrite map_subst_map in h. depelim h.
+        rewrite ih in h. auto.
+      - assert (hlen' : length lb = length la) by lia.
+        replace hlen with (f_equal S hlen') by auto.
+        rewrite map_subst_map.
+        inv h. constructor; auto.
+        rewrite ih. assumption.
+    Qed.
+
+    Polymorphic Lemma vec_Forall2_eq_rect_l :
+      forall {n m} (nm : n = m) (va : Vec.t A n) (vb : Vec.t B m),
+        Vec.Forall2 R (eq_rect _ _ va _ nm) vb
+        <-> Vec.Forall2 R va (eq_rect _ _ vb _ (eq_sym nm)).
+    Proof using.
+      intros n m nm va vb. depelim nm.
+      reflexivity.
+    Qed.
+
+    Polymorphic Lemma vec_Forall2_eq_rect_r :
+      forall {n m} (mn : m = n) (va : Vec.t A n) (vb : Vec.t B m),
+        Vec.Forall2 R va (eq_rect _ _ vb _ mn)
+        <-> Vec.Forall2 R (eq_rect _ _ va _ (eq_sym mn)) vb.
+    Proof using.
+      intros n m nm va vb. depelim nm.
+      reflexivity.
+    Qed.
+  End Forall2.
+  
+  Section Foldrightoflist.
+    Polymorphic Variable f : A -> B -> B.
+    Polymorphic Variable b : B.
+
+    Polymorphic Lemma vec_fold_right_of_list : forall (l : list A),
+        Vec.fold_right f (Vec.of_list l) b = List.fold_right f b l.
+    Proof using.
+      intro l; induction l as [| a l ih]; cbn; f_equal; auto.
+    Qed.
+
+    Polymorphic Lemma vec_fold_right_eq_rect : forall {n m} (nm : n = m) (v : Vec.t A n),
+        Vec.fold_right f (eq_rect _ _ v _ nm) b = Vec.fold_right f v b.
+    Proof using.
+      intros n m nm v; depelim nm. reflexivity.
+    Qed.
+  End Foldrightoflist.
+
+  Section Foldleftoflist.
+    Polymorphic Variable f : B -> A -> B.
+
+    Polymorphic Lemma vec_fold_left_of_list : forall (l : list A) (b : B),
+        Vec.fold_left f b (Vec.of_list l) = List.fold_left f l b.
+    Proof using.
+      intro l; induction l as [| a l ih]; intro b; cbn; f_equal; auto.
+    Qed.
+
+    Polymorphic Lemma vec_fold_left_eq_rect : forall {n m} (nm : n = m) (v : Vec.t A n) (b : B),
+        Vec.fold_left f b (eq_rect _ _ v _ nm) = Vec.fold_left f b v.
+    Proof using.
+      intros n m nm v b. depelim nm. reflexivity.
+    Qed.
+  End Foldleftoflist.
+  
+  Section mapoflist.
+    Import List.ListNotations.
+    Polymorphic Variable f : A -> B.
+
+    Polymorphic Equations my_map_length : forall l : list A,
+        length (List.map f l) = length l := {
+        my_map_length []%list := eq_refl;
+        my_map_length (_ :: t)%list := f_equal S (my_map_length t)
+      }.
+
+    Local Hint Resolve PeanoNat.Nat.eq_dec : core.
+
+    Polymorphic Lemma vec_map_of_list : forall l : list A,
+        Vec.map f (Vec.of_list l)
+        = eq_rect _ _ (Vec.of_list (List.map f l)) _ (my_map_length l).
+    Proof using.
+      intro l; induction l as [| a l ih]; cbn.
+      - rewrite <- Eqdep_dec.eq_rect_eq_dec by auto.
+        reflexivity.
+      - rewrite my_map_length_equation_2.
+        rewrite map_subst_map, ih. reflexivity.
+    Qed.
+
+    Polymorphic Lemma vec_of_list_map : forall l : list A,
+        Vec.of_list (List.map f l)
+        = eq_rect
+            _ _
+            (Vec.map f (Vec.of_list l)) _
+            (eq_sym (my_map_length l)).
+    Proof using.
+      intro l; induction l as [| a l ih]; cbn.
+      - rewrite <- Eqdep_dec.eq_rect_eq_dec by auto.
+        reflexivity.
+      - rewrite my_map_length_equation_2.
+        rewrite eq_sym_map_distr.
+        rewrite map_subst_map, ih. reflexivity.
+    Qed.
+  End mapoflist.
+
+  Section Foralloflistmap.
+    Polymorphic Variable f : A -> B.
+
+    Polymorphic Lemma vec_hd_map : forall {n} (v : Vec.t A (S n)),
+        Vec.hd (Vec.map f v) = f (Vec.hd v).
+    Proof using.
+      intros n v. depelim v; reflexivity.
+    Qed.
+
+    Polymorphic Lemma vec_tl_map : forall {n} (v : Vec.t A (S n)),
+        Vec.tl (Vec.map f v) = Vec.map f (Vec.tl v).
+    Proof using.
+      intros n v; depelim v; reflexivity.
+    Qed.
+
+    Polymorphic Lemma map_to_list : forall {n} (v : Vec.t A n),
+        List.map f (Vec.to_list v) = Vec.to_list (Vec.map f v).
+    Proof using.
+      intros n v. depind v; cbn; f_equal; auto.
+    Qed.
+    
+    Polymorphic Variable P : B -> Prop.
+
+    Local Hint Constructors Vec.Forall : core.
+    
+    Polymorphic Lemma Forall_of_list_map : forall (l : list A),
+        Vec.Forall P (Vec.of_list (List.map f l)) ->
+        Vec.Forall P (Vec.map f (Vec.of_list l)).
+    Proof using.
+      intro l; induction l as [| a l ih]; intro h; cbn in *; depelim h; auto.
+    Qed.
+
+    Polymorphic Lemma Forall_map_of_list : forall (l : list A),
+        Vec.Forall P (Vec.map f (Vec.of_list l)) ->
+        Vec.Forall P (Vec.of_list (List.map f l)).
+    Proof using.
+      intro l; induction l as [| a l ih]; intro h; cbn in *; depelim h; auto.
+    Qed.
+  End Foralloflistmap.
+  
+  (*Polymorphic Lemma map_of_list : forall (f : A -> B) (l : list A),
+    Vec.of_list (List.map f l) = Vec.map f (Vec.of_list l).*)
+  
+  Polymorphic Lemma vec_map2_same : forall {n : nat} (f : A -> A -> B) (v : Vec.t A n),
+      Vec.map2 f v v = Vec.map (fun a => f a a) v.
+  Proof using.
+    intros n f v.
+    depind v; unravel; f_equal; auto.
+  Qed.
+
+  Polymorphic Equations vec_zip : forall {n : nat},
+      Vec.t A n -> Vec.t B n -> Vec.t (A * B) n := {
+      vec_zip [] [] := [];
+      vec_zip (a :: va) (b :: vb) := (a, b) :: vec_zip va vb
+    }.
+
+  Polymorphic Lemma vec_zip_fst : forall {n : nat} (va : Vec.t A n) (vb : Vec.t B n),
+      Vec.map fst (vec_zip va vb) = va.
+  Proof using.
+    intros n va vb.
+    funelim (vec_zip va vb); auto.
+    rewrite vec_zip_equation_2; cbn; f_equal; auto.
+  Qed.
+
+  Polymorphic Lemma vec_zip_snd : forall {n : nat} (va : Vec.t A n) (vb : Vec.t B n),
+      Vec.map snd (vec_zip va vb) = vb.
+  Proof using.
+    intros n va vb.
+    funelim (vec_zip va vb); auto.
+    rewrite vec_zip_equation_2; cbn; f_equal; auto.
+  Qed.
+  
+  Polymorphic Equations vec_unzip : forall {n : nat},
+      Vec.t (A * B) n -> Vec.t A n * Vec.t B n := {
+      vec_unzip [] := ([], []);
+      vec_unzip ((a, b) :: v) :=
+        let '(va, vb) := vec_unzip v in (a :: va, b :: vb)
+    }.
+
+  Polymorphic Lemma vec_unzip_correct : forall {n : nat} (v : Vec.t (A * B) n),
+      vec_unzip v = (Vec.map fst v, Vec.map snd v).
+  Proof using.
+    intros n v.
+    funelim (vec_unzip v); cbn; auto.
+    rewrite vec_unzip_equation_2, H.
+    reflexivity.
+  Qed.
+  
+  Polymorphic Universes c.
+  Polymorphic Context {C : Type@{c}}.
+  
+  Polymorphic Lemma vec_map_rep_r : forall (g : B -> A -> C) {n : nat} (v : Vec.t B n) (a : A),
+      Vec.map2 g v (vec_rep n a) = Vec.map (fun b => g b a) v.
+  Proof using.
+    intros g n v a.
+    depind v; unravel; trivial.
+    f_equal. auto.
+  Qed.
+
+  Polymorphic Lemma vec_map_rep_l : forall (g : A -> B -> C) {n : nat} (v : Vec.t B n) (a : A),
+      Vec.map2 g (vec_rep n a) v = Vec.map (g a) v.
+  Proof using.
+    intros g n v a.
+    depind v; unravel; trivial.
+    f_equal. auto.
+  Qed.
+  
+  Polymorphic Variable f : B -> C.
+
+  Polymorphic Lemma vec_map_snd_map : forall {n : nat} (v : Vec.t (A * B) n),
+      Vec.map snd (Vec.map (fun '(a, b) => (a, f b)) v) = Vec.map f (Vec.map snd v).
+  Proof using.
+    intros n v.
+    depind v; unravel; trivial.
+    destruct h as [a b]; unravel.
+    f_equal. assumption.
+  Qed.
+
+  Polymorphic Lemma vec_map_fst_map : forall {n : nat} (v : Vec.t (B * A) n),
+      Vec.map fst (Vec.map (fun '(b, a) => (f b, a)) v) = Vec.map f (Vec.map fst v).
+  Proof using.
+    intros n v.
+    depind v; unravel; trivial.
+    destruct h as [b a].
+    f_equal. assumption.
+  Qed.
+
+  Polymorphic Lemma vec_ignore_map_fst_map : forall {n : nat} (v : Vec.t (A * B) n),
+      Vec.map fst (Vec.map (fun '(a, b) => (a, f b)) v) = Vec.map fst v.
+  Proof using.
+    intros n v.
+    depind v; unravel; trivial.
+    destruct h as [a b]. f_equal. assumption.
+  Qed.
+
+  Polymorphic Lemma vec_ignore_map_snd_map : forall {n : nat} (v : Vec.t (B * A) n),
+      Vec.map snd (Vec.map (fun '(b, a) => (f b, a)) v) = Vec.map snd v.
+  Proof using.
+    intros n v.
+    depind v; unravel; trivial.
+    destruct h as [b a]. f_equal. assumption.
+  Qed.
+End Lemmas.
+
+Section Map3.
+  Import Vec.VectorNotations.
+  Local Open Scope vector_scope.
+  
+  Polymorphic Universes a b c d.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}} {C : Type@{c}} {D : Type@{d}}.
+  Polymorphic Variable f : A -> B -> C -> D.
+
+  Set Equations Transparent.
+  
+  Polymorphic Equations vec_map3 :
+    forall {n : nat}, Vec.t A n -> Vec.t B n -> Vec.t C n -> Vec.t D n := {
+      vec_map3 [] [] [] := [];
+      vec_map3 (a :: v1) (b :: v2) (c :: v3) :=
+        f a b c :: vec_map3 v1 v2 v3
+    }.
+End Map3.
+
+Section MapRep.
+  Polymorphic Universes a b.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}}.
+  Polymorphic Variable f : A -> B.
+  Polymorphic Variable a : A.
+
+  Polymorphic Lemma vec_rep_map : forall n,
+      Vec.map f (vec_rep n a) = vec_rep n (f a).
+  Proof using.
+    intro n; induction n as [| n ih]; cbn; f_equal; assumption.
+  Qed.
+End MapRep.
+
+
+Section Forall2flip.
+  Polymorphic Universes a b.
+  Polymorphic Context {A : Type@{a}} {B : Type@{b}}.
+  
+  Polymorphic Lemma vec_Forall2_flip :
+    forall (R : A -> B -> Prop) {n} (va : Vec.t A n) (vb : Vec.t B n),
+      Vec.Forall2 R va vb <-> Vec.Forall2 (fun b a => R a b) vb va.
+  Proof using.
+    intros R n va vb.
+    do 2 rewrite vec_Forall2_forall.
+    reflexivity.
+  Qed.
+End Forall2flip.
+
+Section Forall3.
+  Import Vec.VectorNotations.
+  Local Open Scope vector_scope.
+  
+  Polymorphic Universes a b c.
+
+  Section Forall3.
+    Polymorphic Context {A : Type@{a}} {B : Type@{b}} {C : Type@{c}}.
+    Polymorphic Variable R : A -> B -> C -> Prop.
+
+    Polymorphic Inductive vec_Forall3 :
+      forall {n}, Vec.t A n -> Vec.t B n -> Vec.t C n -> Prop :=
+    | vec_Forall3_nil : vec_Forall3 [] [] []
+    | vec_Forall3_cons {n} a b c (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n) :
+      R a b c -> vec_Forall3 va vb vc -> vec_Forall3 (a :: va) (b :: vb) (c :: vc).
+
+    Polymorphic Derive Signature for vec_Forall3.
+
+    Local Hint Constructors vec_Forall3 : core.
+    Local Hint Constructors Vec.Forall2 : core.
+    
+    Polymorphic Lemma vec_Forall3_Forall2_12 :
+      forall {n} (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+        vec_Forall3 va vb vc
+        <-> Vec.Forall2 (uncurry R) (vec_zip va vb) vc.
+    Proof using.
+      intros n va vb vc; split; intro h.
+      - depind h.
+        + rewrite vec_zip_equation_1; auto.
+        + rewrite vec_zip_equation_2; auto.
+      - funelim (vec_zip va vb); depelim vc; auto.
+        rewrite vec_zip_equation_2 in h0.
+        depelim h0. auto.
+    Qed.
+
+    Polymorphic Lemma vec_Forall3_forall : forall {n} (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+        vec_Forall3 va vb vc <-> forall num, R (va [@ num]) (vb [@ num]) (vc [@ num]).
+    Proof using.
+      intros n va vb vc; split; intro h.
+      - intro num. depind h; depelim num; cbn; auto.
+      - generalize dependent vc.
+        generalize dependent vb.
+        depind va; intros vb vc H; depelim vb; depelim vc; auto.
+        pose proof H Fin.F1 as H1; cbn in H1.
+        constructor; auto.
+        apply IHva. intro num.
+        specialize H with (Fin.FS num); cbn in H.
+        assumption.
+    Qed.
+
+    Local Hint Constructors Forall3 : core.
+    
+    Polymorphic Lemma vec_Forall3_to_list :
+      forall {n} (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+        Forall3 R (Vec.to_list va) (Vec.to_list vb) (Vec.to_list vc)
+        <-> vec_Forall3 va vb vc.
+    Proof using.
+      intros n va vb vc; split; intro h.
+      - generalize dependent vc.
+        generalize dependent vb.
+        depind va; intros vb vc H; depelim vb; depelim vc;
+          cbn in *; inv H; auto.
+      - depind h; cbn; auto.
+    Qed.
+
+    Local Hint Resolve PeanoNat.Nat.eq_dec : core.
+    Local Hint Resolve Peano_dec.UIP_nat : core.
+    
+    Polymorphic Lemma vec_Forall3_of_list :
+      forall la lb lc (hlenba : length lb = length la) (hlenca : length lc = length la),
+        vec_Forall3
+          (Vec.of_list la)
+          (eq_rect _ _ (Vec.of_list lb) _ hlenba)
+          (eq_rect _ _ (Vec.of_list lc) _ hlenca)
+        <-> Forall3 R la lb lc.
+    Proof using.
+      intros la lb lc hba hca; split.
+      - generalize dependent lc.
+        generalize dependent lb.
+        induction la as [| a la ih];
+          intros [| b lb] hba [| c lc] hca h; cbn in *;
+          try discriminate; auto.
+        assert (length lb = length la) as hab by lia.
+        assert (length lc = length la) as hac by lia.
+        replace hba with (f_equal S hab) in h by auto.
+        replace hca with (f_equal S hac) in h by auto.
+        do 2 rewrite map_subst_map in h.
+        depelim h. eauto.
+      - intro h; induction h; cbn in *.
+        + do 2 rewrite <- Eqdep_dec.eq_rect_eq_dec by auto; auto.
+        + assert (length us = length ts) as hab by lia.
+          assert (length vs = length ts) as hac by lia.
+          replace hba with (f_equal S hab) by auto.
+          replace hca with (f_equal S hac) by auto.
+          do 2 rewrite map_subst_map. auto.
+    Qed.
+
+    Polymorphic Lemma vec_Forall3_eq_rect_l_to_mr :
+      forall {n m} (nm : n = m) (va : Vec.t A n) (vb : Vec.t B m) (vc : Vec.t C m),
+        vec_Forall3 (eq_rect _ _ va _ nm) vb vc
+        <-> vec_Forall3
+            va (eq_rect _ _ vb _ (eq_sym nm))
+            (eq_rect _ _ vc _ (eq_sym nm)).
+    Proof using.
+      intros n m nm va vb vc.
+      depelim nm. reflexivity.
+    Qed.
+    
+    Polymorphic Lemma vec_Forall3_eq_rect_m_to_lr :
+      forall {n m} (nm : n = m) (va : Vec.t A m) (vb : Vec.t B n) (vc : Vec.t C m),
+        vec_Forall3 va (eq_rect _ _ vb _ nm) vc
+        <-> vec_Forall3
+            (eq_rect _ _ va _ (eq_sym nm)) vb
+            (eq_rect _ _ vc _ (eq_sym nm)).
+    Proof using.
+      intros n m nm va vb vc.
+      depelim nm. reflexivity.
+    Qed.
+    
+    Polymorphic Lemma vec_Forall3_eq_rect_r_to_lm :
+      forall {n m} (nm : n = m) (va : Vec.t A m) (vb : Vec.t B m) (vc : Vec.t C n),
+        vec_Forall3 va vb (eq_rect _ _ vc _ nm)
+        <-> vec_Forall3
+            (eq_rect _ _ va _ (eq_sym nm))
+            (eq_rect _ _ vb _ (eq_sym nm)) vc.
+    Proof using.
+      intros n m nm va vb vc.
+      depelim nm. reflexivity.
+    Qed.
+  End Forall3.
+
+  Local Hint Constructors vec_Forall3 : core.
+  
+  Section Forall3.
+    Polymorphic Context {A : Type@{a}} {B : Type@{b}} {C : Type@{c}}.
+  
+    Polymorphic Lemma vec_Forall3_permute_12 :
+      forall (R : A -> B -> C -> Prop) {n}
+        (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+        vec_Forall3 R va vb vc
+        <-> vec_Forall3 (fun b a => R a b) vb va vc.
+    Proof using.
+      intros R n va vb vc; split; intro h; depind h; auto.
+    Qed.
+    
+    Polymorphic Lemma vec_Forall3_permute_13 :
+      forall (R : A -> B -> C -> Prop) {n}
+        (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+        vec_Forall3 R va vb vc
+        <-> vec_Forall3 (fun c b a => R a b c) vc vb va.
+    Proof using.
+      intros R n va vb vc; split; intro h; depind h; auto.
+    Qed.
+    
+    Polymorphic Lemma vec_Forall3_permute_23 :
+      forall (R : A -> B -> C -> Prop) {n}
+        (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+        vec_Forall3 R va vb vc
+        <-> vec_Forall3 (fun a c b => R a b c) va vc vb.
+    Proof using.
+      intros R n va vb vc; split; intro h; depind h; auto.
+    Qed.
+  End Forall3.
+    
+  Polymorphic Lemma vec_Forall3_Forall2_23 :
+    forall {A : Type@{a}} {B : Type@{b}} {C : Type@{c}}
+      (R : A -> B -> C -> Prop) {n}
+      (va : Vec.t A n) (vb : Vec.t B n) (vc : Vec.t C n),
+      vec_Forall3 R va vb vc
+      <-> Vec.Forall2 (fun a => uncurry (R a)) va (vec_zip vb vc).
+  Proof using.
+    intros A B C R n va vb vc.
+    rewrite vec_Forall3_permute_12.
+    rewrite vec_Forall3_permute_23.
+    rewrite vec_Forall3_Forall2_12.
+    rewrite vec_Forall2_flip.
+    do 2 rewrite vec_Forall2_forall.
+    unfold uncurry.
+    intuition; specialize H with m;
+      do 2 let_destr_pair; assumption.
+  Qed.
+End Forall3.


### PR DESCRIPTION
Shifting operations on P4cub terms during the lifting pass now share one definition and specification.

An arbitrary-length product type is the foundation of these changes.