### PR TITLE
SetValid is now a statement in cub

### DIFF
--- a/coq/lib/Ccomp/CCompSel.v
+++ b/coq/lib/Ccomp/CCompSel.v
@@ -203,11 +203,6 @@ Section CCompSel.
         let* env := get_state in
         let^ index := state_lift (ValidBitIndex arg env) in
         Sassign dst' (Efield arg' index type_bool)
-    | Una.SetValidity valid =>
-        let* env := get_state in
-        let^ index := state_lift (ValidBitIndex arg env) in
-        let member :=  Efield arg' index type_bool in
-        Sassign member (if valid then Ctrue else Cfalse)
     end.
  
   Definition bop_function (op: ident) := 
@@ -998,6 +993,12 @@ Section CCompSel.
     | Stm.Trans pe =>
         (* TODO: is this correct? *)
         CTranslateParserExpression pe
+    | Stm.SetValidity valid arg =>
+        let* arg' := CTranslateExpr arg in
+        let* env := get_state in
+        let^ index := state_lift (ValidBitIndex arg env) in
+        let member :=  Efield arg' index type_bool in
+        Sassign member (if valid then Ctrue else Cfalse)
     end.
   
   Definition CTranslateParserState

--- a/coq/lib/Compile/ToP4cub.v
+++ b/coq/lib/Compile/ToP4cub.v
@@ -866,7 +866,7 @@ Section ToP4cub.
       
       Definition translate_set_validity v callee :=
         let+ hdr := translate_expression callee in
-        ST.Asgn hdr (Exp.Uop Typ.Bool (Una.SetValidity v) hdr).
+        ST.SetValidity v hdr.
       
       Definition translate_is_valid callee retvar :=
         let* hdr := translate_expression callee in

--- a/coq/lib/GCL/GCL.v
+++ b/coq/lib/GCL/GCL.v
@@ -1,3 +1,4 @@
+
 Set Warnings "-custom-entry-overridden".
 From Coq Require Import Program.Basics Arith.EqNat.
 From Poulet4 Require Export P4cub.Syntax.AST
@@ -167,7 +168,6 @@ Section GCL.
   Inductive t {lvalue rvalue form : Type} : Type :=
   | GSkip
   | GAssign (type : Typ.t) (lhs : lvalue) (rhs : rvalue)
-  | GSetValidity (valid : bool) (hdr : lvalue)
   | GSeq (g1 g2 : t)
   | GChoice (g1 g2 : t)
   | GAssume (phi : form)
@@ -192,8 +192,6 @@ Section GCL.
     | GSkip => GSkip
     | GAssign t x e =>
       GAssign t (l param phi x) (r param phi e)
-    | GSetValidity b e =>
-      GSetValidity b e (* TODO: is this correct? *)
     | GSeq g1 g2 =>
       GSeq (subst_form l r f param phi g1) (subst_form l r f param phi g2)
     | GChoice g1 g2 =>
@@ -216,7 +214,6 @@ Section GCL.
     | GSkip => GSkip
     | GAssign t x e' =>
       GAssign t (l param e x) (r param e e')
-    | GSetValidity b e => GSetValidity b e
     | GSeq g1 g2 =>
       GSeq (subst_rvalue l r f param e g1) (subst_rvalue l r f param e g2)
     | GChoice g1 g2 =>
@@ -514,9 +511,6 @@ Module Semantics.
       | GCL.GAssign _ lhs rhs =>
         let+ bv := eval s rhs in
         [update s lhs bv]
-      | GCL.GSetValidity b e =>
-      (* TODO: not sure how to evaluate this *)
-          error "how to make valid or not?"
       | GCL.GSeq g1 g2 =>
         let* ss1 := denote a s g1 in
         fold_right (fun s1 acc => let* s := denote a s1 g2 in

--- a/coq/lib/GCL/GCL.v
+++ b/coq/lib/GCL/GCL.v
@@ -167,6 +167,7 @@ Section GCL.
   Inductive t {lvalue rvalue form : Type} : Type :=
   | GSkip
   | GAssign (type : Typ.t) (lhs : lvalue) (rhs : rvalue)
+  | GSetValidity (valid : bool) (hdr : lvalue)
   | GSeq (g1 g2 : t)
   | GChoice (g1 g2 : t)
   | GAssume (phi : form)
@@ -191,6 +192,8 @@ Section GCL.
     | GSkip => GSkip
     | GAssign t x e =>
       GAssign t (l param phi x) (r param phi e)
+    | GSetValidity b e =>
+      GSetValidity b e (* TODO: is this correct? *)
     | GSeq g1 g2 =>
       GSeq (subst_form l r f param phi g1) (subst_form l r f param phi g2)
     | GChoice g1 g2 =>
@@ -213,6 +216,7 @@ Section GCL.
     | GSkip => GSkip
     | GAssign t x e' =>
       GAssign t (l param e x) (r param e e')
+    | GSetValidity b e => GSetValidity b e
     | GSeq g1 g2 =>
       GSeq (subst_rvalue l r f param e g1) (subst_rvalue l r f param e g2)
     | GChoice g1 g2 =>
@@ -510,6 +514,9 @@ Module Semantics.
       | GCL.GAssign _ lhs rhs =>
         let+ bv := eval s rhs in
         [update s lhs bv]
+      | GCL.GSetValidity b e =>
+      (* TODO: not sure how to evaluate this *)
+          error "how to make valid or not?"
       | GCL.GSeq g1 g2 =>
         let* ss1 := denote a s g1 in
         fold_right (fun s1 acc => let* s := denote a s1 g2 in

--- a/coq/lib/GCL/Inline.v
+++ b/coq/lib/GCL/Inline.v
@@ -871,17 +871,17 @@ Definition header_fields  (e : E.t) (fields : list Typ.t) : list (E.t * Typ.t)  
     ++ [(E.Uop Typ.Bool Una.IsValid e , Typ.Bool)].
 
 Definition header_elaboration_assign  (lhs rhs : E.t) (fields : list Typ.t) : result string t :=
-  let lhs_members := header_fields  lhs fields in
+  let lhs_members := header_fields lhs fields in
   let rhs_members := header_fields  rhs fields in
   let+ assigns := zip lhs_members rhs_members  in
   let f := fun '((lhs_mem, typ), (rhs_mem, _)) acc => ISeq (IAssign typ lhs_mem rhs_mem ) acc  in
-  List.fold_right f (ISkip ) assigns.
+  List.fold_right f ISkip assigns.
 
 Fixpoint elaborate_headers (c : Inline.t) : result string Inline.t :=
   match c with
   | ISkip => ok c
   | IVardecl _ _ => ok c
-  | ISetValidity _ _ => ok c (* TODO: I don't know if this is correct *)
+  | ISetValidity _ _ => ok c
   | IAssign type lhs rhs =>
     match type with
     | Typ.Struct true fields =>
@@ -1120,7 +1120,7 @@ Definition inline_assert (check : E.t)  : t :=
   IExternMethodCall "_" "assert" args None.
 
 Definition isValid (hdr : E.t) : E.t :=
-  E.Uop Typ.Bool Una.IsValid hdr .
+  E.Uop Typ.Bool Una.IsValid hdr.
 
 Fixpoint header_asserts (e : E.t) : result string t :=
   match e with

--- a/coq/lib/GCL/ToGCL.v
+++ b/coq/lib/GCL/ToGCL.v
@@ -340,13 +340,7 @@ Section ToGCL.
         | Una.IsValid =>
           let+ header := to_lvalue arg in
           let hvld := header @@ ".is_valid" in
-          BV.BVVar hvld 1
-        | Una.SetValidity b =>
-            (* TODO @Rudy isn't this a command? *)
-            (* TODO @Eric the uop [SetValid] is now [SetValidity true]
-               and [SetInvalid] is now [SetValidity false]. *)
-          error "SetValidity is unimplemented"
-        end
+          BV.BVVar hvld 1        end
       | E.Bop typ op lhs rhs =>
         let* l := to_rvalue lhs in
         let* r := to_rvalue rhs in
@@ -507,8 +501,6 @@ Section ToGCL.
           let+ header := to_lvalue arg in
           let hvld := header @@ ".is_valid" in
           GCL.isone (BV.BVVar hvld 1)
-        | Una.SetValidity b =>
-          error "TODO: implement case for E.Setvalidity"
         end
       | E.Bop typ op lhs rhs =>
         let lbin := fun o => let* l := to_form lhs in
@@ -627,6 +619,10 @@ Section ToGCL.
         let e := GCL.GAssign type lhs' rhs' in
         ok (e, c)
 
+      | Inline.ISetValidity b e =>
+          let~ e' := to_lvalue (scopify c e) over "couldn't convert e of ISetValidity to lvalue" in
+          ok (GCL.GSetValidity b e', c)
+           
       | Inline.IConditional guard_type guard tru_blk fls_blk =>
         let* tru_blk' := inline_to_gcl c arch tru_blk in
         let* fls_blk' := inline_to_gcl c arch fls_blk in

--- a/coq/lib/GCL/ToGCL.v
+++ b/coq/lib/GCL/ToGCL.v
@@ -620,8 +620,9 @@ Section ToGCL.
         ok (e, c)
 
       | Inline.ISetValidity b e =>
-          let~ e' := to_lvalue (scopify c e) over "couldn't convert e of ISetValidity to lvalue" in
-          ok (GCL.GSetValidity b e', c)
+          let~ hdr_str := to_lvalue (scopify c e) over "couldn't convert e of ISetValidity to lvalue" in
+          let validity := hdr_str @@ ".isValid" in
+          ok (GCL.GAssign Typ.Bool validity (BV.bit (Some 1) 1), c)
            
       | Inline.IConditional guard_type guard tru_blk fls_blk =>
         let* tru_blk' := inline_to_gcl c arch tru_blk in

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/ExprUtil.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/ExprUtil.v
@@ -61,8 +61,6 @@ Definition eval_una (op : Una.t) (v : Val.t) : option Val.t :=
   | `-%una, w VS z => Some $ Val.Int w $ IntArith.neg w z
   | Una.IsValid, Val.Lists (Lst.Header b) _
     => Some (Val.Bool b)
-  | Una.SetValidity b, Val.Lists _ vs
-    => Some $ Val.Lists (Lst.Header b) vs
   | _, _ => None
   end.
 

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Properties.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Properties.v
@@ -865,6 +865,8 @@ Section Properties.
     - pose proof shift_lv_update _ _ _ _ _ _ hus huseps' vs as hvs.
       rewrite <- hvs.
       constructor; auto.
+    - pose proof shift_lv_update _ _ _ _ _ _ hus huseps' vs0 as hvs.
+      rewrite <- hvs. eauto.
     - set (vargs' :=
              map (paramarg_map id (shift_lv
                                      {|
@@ -983,6 +985,7 @@ Section Properties.
         by (rewrite !app_length; lia).
       apply sublist.app_eq_len_eq in h as [husvs _]; auto.
     - apply shift_exp_lv_eval_shift_lv_exists in H4 as [lv' ?]; subst. eauto 2.
+    - apply shift_exp_lv_eval_shift_lv_exists in H4 as [lv' ?]; subst. eauto 2.
     - destruct call as [g ts oe | | |]; unravel in *; inv H.
       apply args_eval_shift_exp_exists_shift_varg in H6 as [vargs' ?]; subst.
       apply relop_lexp_big_step_exists_shift in H3 as [olv' ?]; subst.
@@ -1038,6 +1041,10 @@ Section Properties.
     - inv hctx.
       pose proof sbs_length _ _ _ _ _ _ _ H6 as hϵ3.
       admit.
+    - pose proof shift_exp_lv_eval_shift_lv_exists
+        _ _ _ _ _ H4 as [lv' ?]; subst.
+      apply lv_update_shift in H3 as h; eauto.
+      rewrite <- h. eauto.
     - pose proof shift_exp_lv_eval_shift_lv_exists
         _ _ _ _ _ H4 as [lv' ?]; subst.
       apply lv_update_shift in H3 as h; eauto.

--- a/coq/lib/P4cub/Semantics/Dynamic/BigStep/Semantics.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/BigStep/Semantics.v
@@ -299,6 +299,10 @@ Inductive stm_big_step
   l⟨ ϵ, e₁ ⟩ ⇓ lv ->
   ⟨ ϵ, e₂ ⟩ ⇓ v ->
   ⧼ Ψ, ϵ, c, e₁ `:= e₂ ⧽ ⤋ ⧼ lv_update lv v ϵ, Cont, extrn_state Ψ ⧽
+| sbs_setvalidity ϵ c b oldb e lv vs :
+  l⟨ ϵ, e ⟩ ⇓ lv ->
+  ⟨ ϵ, e ⟩ ⇓ Val.Lists (Lst.Header oldb) vs ->
+  ⧼ Ψ, ϵ, c, Stm.SetValidity b e ⧽ ⤋ ⧼ lv_update lv (Val.Lists (Lst.Header b) vs) ϵ, Cont, extrn_state Ψ ⧽
 | sbs_funct_call
     ϵ ϵ' ϵ'' c ψ f τs args
     eo vargs olv fun_clos body sig :

--- a/coq/lib/P4cub/Semantics/Dynamic/SmallStep/Util.v
+++ b/coq/lib/P4cub/Semantics/Dynamic/SmallStep/Util.v
@@ -71,8 +71,6 @@ Section StepDefs.
     | `-%una, (w `W z)%exp => Some $ Exp.Bit w $ BitArith.neg w z
     | `-%una, (w `S z)%exp => Some $ Exp.Int w $ IntArith.neg w z
     | Una.IsValid, Exp.Lists (Lst.Header b) _ => Some $ Exp.Bool b
-    | Una.SetValidity b, Exp.Lists _ fs
-      => Some $ Exp.Lists (Lst.Header b) fs
     | _, _ => None
     end.
 
@@ -318,7 +316,6 @@ Section StepDefs.
                | H: Some _ = Some _ |- _ => inv H
                end; eauto 2.
       - destruct x; discriminate || some_inv; auto.
-      - inv H3; eauto.
     Qed.
   End HelpersType.
   

--- a/coq/lib/P4cub/Semantics/Static/Typing.v
+++ b/coq/lib/P4cub/Semantics/Static/Typing.v
@@ -171,7 +171,11 @@ Inductive type_stm (Δ : nat) (Γ : list Typ.t) (fs : fenv)
   `⟨ Δ, Γ ⟩ ⊢ e₁ ∈ τ ->
   `⟨ Δ, Γ ⟩ ⊢ e₂ ∈ τ ->
   `⧼ Δ, Γ, fs, c ⧽ ⊢ e₁ `:= e₂ ⊣ Signal.Cnt
-| type_fun_call c params τs args fk :
+| type_setvalidity c b e τs :
+  lexpr_ok e ->
+  `⟨ Δ, Γ ⟩ ⊢ e ∈ Typ.Struct true τs ->
+  `⧼ Δ, Γ, fs, c ⧽ ⊢ Stm.SetValidity b e ⊣ Signal.Cnt
+| type_app c params τs args fk :
   type_call Δ Γ fs c fk τs params ->
   Forall (typ_ok Δ) τs ->
   type_args Δ Γ args (map (tsub_param (gen_tsub τs)) (map snd params)) ->

--- a/coq/lib/P4cub/Semantics/Static/Util.v
+++ b/coq/lib/P4cub/Semantics/Static/Util.v
@@ -42,9 +42,7 @@ Variant una_type : Una.t -> Typ.t -> Typ.t -> Prop :=
   | una_UMinus τ :
     numeric τ -> una_type `-%una τ τ
   | una_IsValid ts :
-    una_type Una.IsValid (Typ.Struct true ts) Typ.Bool
-  | una_SetValidity b ts :
-    una_type (Una.SetValidity b) (Typ.Struct true ts) (Typ.Struct true ts).
+    una_type Una.IsValid (Typ.Struct true ts) Typ.Bool.
 
 (** Evidence a binary operation is valid
     for operands of a type and produces some type. *)

--- a/coq/lib/P4cub/Syntax/AST.v
+++ b/coq/lib/P4cub/Syntax/AST.v
@@ -103,8 +103,7 @@ Module Una.
     | Not                        (** boolean negation *)
     | BitNot                     (** bitwise negation *)
     | Minus                      (** integer negation *)
-    | IsValid                    (** check header validity *)
-    | SetValidity (validity : bool) (** set a header's validity to [validity] *).
+    | IsValid                    (** check header validity *).
 End Una.
 
 (** Binary operations. *)
@@ -225,6 +224,7 @@ Module Stm.
   | Exit                                               (** exit *)
   | Trans (trns : Trns.t)                              (** parser transition *)  
   | Asgn (lhs rhs : Exp.t)                            (** assignment *)
+  | SetValidity (validity : bool) (hdr : Exp.t) (** set a header [hdr]'s validity to [validity] *)
   | App (call : Call.t) (args : Exp.args)             (** procedural application *)
   | Invoke (lhs : option Exp.t) (table_name : string) (** table invocation *)
       

--- a/coq/lib/P4cub/Syntax/Equality.v
+++ b/coq/lib/P4cub/Syntax/Equality.v
@@ -161,8 +161,6 @@ Global Instance UopEqDec : EqDec Una.t eq.
 Proof.
   intros [] []; unravel in *; firstorder;
     try (right; intros ?; discriminate).
-  elim validity; elim validity0; auto;
-    try (right; intros ?; discriminate).
 Defined.
   
 Global Instance BopEqDec : EqDec Bin.t eq.

--- a/coq/lib/P4cub/Syntax/HeaderStack.v
+++ b/coq/lib/P4cub/Syntax/HeaderStack.v
@@ -119,12 +119,7 @@ Definition
           (Exp.Bop
              (Typ.Bit 32%N)
              `-%bin i count_bit32))%stm in
-  let asgn_front i :=
-    (hdsa i `:=
-          Exp.Uop
-          header_type
-          (Una.SetValidity false)
-          (hdsa i))%stm in
+  let asgn_front i := Stm.SetValidity false $ hdsa i in
   let asgn_pusheds :=
     seq count_nat (N.to_nat size)
         ▷ List.map bit32_of_nat
@@ -158,12 +153,7 @@ Definition
           (Exp.Bop
              (Typ.Bit 32%N) `+%bin
              i count_bit32))%stm in
-  let asgn_last i :=
-    (hdsa i `:=
-          Exp.Uop
-          header_type
-          (Una.SetValidity false)
-          (hdsa i))%stm in
+  let asgn_last i := Stm.SetValidity false $ hdsa i in
   let size_nat := N.to_nat size in
   let mid :=  size_nat - count_nat in
   let asgn_poppeds :=

--- a/coq/lib/P4cub/Syntax/InferMemberTypes.v
+++ b/coq/lib/P4cub/Syntax/InferMemberTypes.v
@@ -60,6 +60,7 @@ Fixpoint inf_stm  (s : Stm.t) : Stm.t :=
   | Stm.Ret e      => Stm.Ret $ option_map inf_exp e
   | Stm.Trans e  => Stm.Trans $ inf_trns e
   | (lhs `:= rhs)%stm => (inf_exp lhs `:= inf_exp rhs)%stm
+  | Stm.SetValidity b e => Stm.SetValidity b $ inf_exp e
   | Stm.Invoke e t
     => Stm.Invoke (option_map inf_exp e) t
   | Stm.App fk args

--- a/coq/lib/P4cub/Syntax/Shift.v
+++ b/coq/lib/P4cub/Syntax/Shift.v
@@ -172,6 +172,7 @@ Fixpoint shift_stm
   | Stm.Trans e
     => Stm.Trans $ shift_trns sh e
   | e1 `:= e2 => shift_exp sh e1 `:= shift_exp sh e2
+  | Stm.SetValidity b e => Stm.SetValidity b $ shift_exp sh e
   | Stm.Invoke e t
     => Stm.Invoke (option_map (shift_exp sh) e) t
   | Stm.App fk args
@@ -327,6 +328,7 @@ Fixpoint rename_stm (ρ : nat -> nat) (s : Stm.t) : Stm.t :=
   | Stm.Trans e
     => Stm.Trans $ rename_trns ρ e
   | e1 `:= e2 => rename_exp ρ e1 `:= rename_exp ρ e2
+  | Stm.SetValidity b e => Stm.SetValidity b $ rename_exp ρ e
   | Stm.Invoke e t
     => Stm.Invoke (option_map (rename_exp ρ) e) t
   | Stm.App fk args
@@ -403,6 +405,7 @@ Fixpoint exp_sub_stm (σ : nat -> Typ.t -> String.string -> Exp.t) (s : Stm.t) :
   | Stm.Ret (Some e) => Stm.Ret $ Some $ exp_sub_exp σ e
   | Stm.Trans e => Stm.Trans $ exp_sub_trns σ e
   | e₁ `:= e₂ => exp_sub_exp σ e₁ `:= exp_sub_exp σ e₂
+  | Stm.SetValidity b e => Stm.SetValidity b $ exp_sub_exp σ e
   | Stm.Invoke e t => Stm.Invoke (option_map (exp_sub_exp σ) e) t
   | Stm.App fk args => Stm.App (exp_sub_call σ fk) $ List.map (exp_sub_arg σ) args
   | `let og := te `in s => `let og := map_sum id (exp_sub_exp σ) te `in exp_sub_stm (exts σ) s

--- a/coq/lib/P4cub/Syntax/Substitution.v
+++ b/coq/lib/P4cub/Syntax/Substitution.v
@@ -98,6 +98,7 @@ Section Sub.
     | Stm.Trans e => Stm.Trans $ tsub_trns e
     | (lhs `:= rhs)%stm
       => (tsub_exp lhs `:= tsub_exp rhs)%stm
+    | Stm.SetValidity b e => Stm.SetValidity b $ tsub_exp e
     | Stm.Invoke e t
       => Stm.Invoke (option_map tsub_exp e) t
     | Stm.App fk args

--- a/coq/lib/P4cub/Transformations/Lifting/EvalSpec.v
+++ b/coq/lib/P4cub/Transformations/Lifting/EvalSpec.v
@@ -247,6 +247,8 @@ Section StatementLifting.
     - pose proof Lift_exp_good_lv _ _ _ H _ _ H3 as (vs1 & hvs1 & hv1).
       pose proof Lift_exp_good _ _ _ H0 _ _ H5 as (vs2 & hvs2 & hv2).
       eapply eval_decl_list_Unwind; eauto. admit. admit.
+    - pose proof Lift_exp_good_lv _ _ _ H _ _ H4 as (vs1 & hvs1 & hv1).
+      pose proof Lift_exp_good _ _ _ H0 _ _ H4 as (vs2 & hvs2 & hv2). admit.
     - admit.
     - admit.
     - admit.

--- a/coq/lib/P4cub/Transformations/Lifting/Lift.v
+++ b/coq/lib/P4cub/Transformations/Lifting/Lift.v
@@ -285,6 +285,9 @@ Inductive Lift_stm : Stm.t -> Stm.t -> Prop :=
        (shift_list shift_exp (Shifter 0 (length es1)) es2 ++ es1)
        (shift_exp (Shifter 0 (length es2)) e1'
           `:= shift_exp (Shifter (length es2) (length es1)) e2'))
+| Lift_setvalidity b e e' es :
+  Lift_exp e e' es ->
+  Lift_stm (Stm.SetValidity b e) (Unwind es (Stm.SetValidity b e'))
 | Lift_invoke_none t :
   Lift_stm (Stm.Invoke None t) (Stm.Invoke None t)
 | Lift_invoke e e' t es :

--- a/coq/lib/P4cub/Transformations/Lifting/Lifted.v
+++ b/coq/lib/P4cub/Transformations/Lifting/Lifted.v
@@ -106,6 +106,9 @@ Inductive lifted_stm : Stm.t -> Prop :=
   lifted_exp e1 ->
   lifted_exp e2 ->
   lifted_stm (e1 `:= e2)%stm
+| lifted_setvalidity b e :
+  lifted_exp e ->
+  lifted_stm (Stm.SetValidity b e)
 | lifted_cond e s1 s2 :
   lifted_exp e ->
   lifted_stm s1 ->
@@ -522,6 +525,8 @@ Proof.
     apply lift_exp_lifted_exp in Heqp as [? ?], Heqp0 as [? ?].
     apply Unwind_lifted; auto.
     rewrite Forall_app; auto.
+  - destruct (lift_exp hdr) as [e' le] eqn:eqe.
+    apply lift_exp_lifted_exp in eqe as [? ?]; auto.
   - destruct (lift_call call) as [fk' lfk] eqn:eqfk.
     destruct (lift_args args) as [args' largs] eqn:eqargs.
     apply lift_call_lifted_call in eqfk as [? ?].

--- a/coq/lib/P4cub/Transformations/Lifting/Statementize.v
+++ b/coq/lib/P4cub/Transformations/Lifting/Statementize.v
@@ -169,6 +169,9 @@ Fixpoint lift_stm (s : Stm.t) : Stm.t :=
         (shift_list shift_exp (Shifter 0 (length le1)) le2 ++ le1)
         (shift_exp (Shifter 0 (length le2)) e1
            `:= shift_exp (Shifter (length le2) (length le1)) e2)
+  | Stm.SetValidity b e
+    => let '(e, le) := lift_exp e in
+      Unwind le $ Stm.SetValidity b e
   | Stm.Invoke (Some e) t
     => let '(e, le) := lift_exp e in
       Unwind le $ Stm.Invoke (Some e) t

--- a/lib/compcertalize.ml
+++ b/lib/compcertalize.ml
@@ -98,7 +98,6 @@ let convert_una (u:Prev.Una.t) =
     | Prev.Una.BitNot -> Una.BitNot 
     | Prev.Una.Minus -> Una.Minus
     | Prev.Una.IsValid -> Una.IsValid
-    | Prev.Una.SetValidity b -> Una.SetValidity b
 
 let convert_bin (b: Prev.Bin.t) = 
     match b with
@@ -217,6 +216,8 @@ let rec stm_convert (s:  Prev.Stm.t) =
     | Prev.Stm.Asgn (x,y) ->
         Stm.Asgn (convert_expression x,
         convert_expression y)
+    | Prev.Stm.SetValidity (b,e) ->
+        Stm.SetValidity (b, convert_expression e)
     | Prev.Stm.Cond (e,x,y) ->
         Stm.Cond (convert_expression e,
         stm_convert x, stm_convert y)

--- a/lib/p4cubSexp.ml
+++ b/lib/p4cubSexp.ml
@@ -11,15 +11,11 @@ let sexp_of_bit_type width = make_sexp "Typ.Bool" [ Bigint.sexp_of_t width ]
 let sexp_of_int_type width = make_sexp "Typ.Int" [ Bigint.sexp_of_t width ]
 let sexp_of_type_var idx = make_sexp "Typ.Var" [ sexp_of_int idx ]
 
-let sexp_of_set_validity valid =
-  make_sexp "Una.SetValidity" [ sexp_of_bool valid ]
-
 let sexp_of_una = function
   | Una.Not -> Sexp.Atom "Una.Not"
   | Una.BitNot -> Sexp.Atom "Una.BitNot"
   | Una.Minus -> Sexp.Atom "Una.Minus"
   | Una.IsValid -> Sexp.Atom "Una.IsValid"
-  | Una.SetValidity valid -> sexp_of_set_validity valid
 
 let string_of_bin = function
   | Bin.Plus -> "Bin.Plus"
@@ -242,12 +238,16 @@ let map_sum f g =
 
 let sexp_of_var_init = map_sum sexp_of_type sexp_of_exp
 
+let sexp_of_set_validity valid e =
+  make_sexp "Stm.SetValidity" [ sexp_of_bool valid; sexp_of_exp e ]
+
 let rec sexp_of_stm = function
   | Stm.Skip -> Sexp.Atom "Stm.Skip"
   | Stm.Ret e -> sexp_of_return e
   | Stm.Exit -> Sexp.Atom "Stm.Exit"
   | Stm.Trans trans -> sexp_of_transition_stm trans
   | Stm.Asgn (lhs, rhs) -> sexp_of_assign lhs rhs
+  | Stm.SetValidity (b, e) -> sexp_of_set_validity b e
   | Stm.App (call, args) -> sexp_of_app call args
   | Stm.Invoke (eo, name) -> sexp_of_invoke eo name
   | Stm.LetIn (x, e, tail) -> sexp_of_var_decl x e tail

--- a/lib/printp4cub.ml
+++ b/lib/printp4cub.ml
@@ -27,8 +27,6 @@ let print_una p u =
   | Una.BitNot -> "BitNot"
   | Una.Minus -> "UMinus"
   | Una.IsValid -> "IsValid"
-  | Una.SetValidity true -> "SetValid"
-  | Una.SetValidity false -> "SetInValid"
   in
 fprintf p "%s" s
 
@@ -260,6 +258,10 @@ let rec print_stm p =
     fprintf p "SAssign @[%a := %a@]"
     print_exp e1
     print_exp e2
+  | Stm.SetValidity (b, e) ->
+    fprintf p "%s %a"
+    (if b then "SetValid" else "SetInValid")
+    print_exp e
   | Stm.Cond (e,s1,s2) ->
     fprintf p "SConditional @[if (%a) then (%a) else (%a)@]" 
     print_exp e


### PR DESCRIPTION
P4cub changed `SetValid` from a unary operation to a statement.

Adjustments were made in the `GCL` library to get petr4 to build that probably are not correct so @ericthewry feel free to make changes and corrections.