### PR TITLE
avoid Map incompatibility in core.v0.16.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
    cstruct-sexp
    menhir
    ANSITerminal
-   (core (>= "0.15.0"))
+   (core (and (>= "0.15.0") (<= "0.16.0")))
    (pp (>= "1.1.2"))
    ppx_deriving_yojson
    (ppx_import (>= "0.15.0"))

--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
    cstruct-sexp
    menhir
    ANSITerminal
-   (core (and (>= "0.15.0") (<= "0.16.0")))
+   (core (and (>= "v0.15.0") (< "v0.16.0")))
    (pp (>= "1.1.2"))
    ppx_deriving_yojson
    (ppx_import (>= "0.15.0"))

--- a/petr4.opam
+++ b/petr4.opam
@@ -31,7 +31,7 @@ depends: [
   "cstruct-sexp"
   "menhir"
   "ANSITerminal"
-  "core" {>= "0.15.0" & <= "0.16.0"}
+  "core" {>= "v0.15.0" & < "v0.16.0"}
   "pp" {>= "1.1.2"}
   "ppx_deriving_yojson"
   "ppx_import" {>= "0.15.0"}

--- a/petr4.opam
+++ b/petr4.opam
@@ -23,7 +23,6 @@ depends: [
   "conf-m4"
   "poulet4"
   "poulet4_Ccomp"
-  "coq-compcert"
   "alcotest"
   "bignum"
   "ocaml" {>= "4.09.1"}
@@ -32,7 +31,7 @@ depends: [
   "cstruct-sexp"
   "menhir"
   "ANSITerminal"
-  "core" {>= "0.15.0"}
+  "core" {>= "0.15.0" & <= "0.16.0"}
   "pp" {>= "1.1.2"}
   "ppx_deriving_yojson"
   "ppx_import" {>= "0.15.0"}


### PR DESCRIPTION
This PR constrains the installed version of Core to be v0.15. I think the fix for the Map issue is quick though.

Fixes #447.